### PR TITLE
Asymmetric gaussian integration issues

### DIFF
--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -81,7 +81,7 @@ class AsymmetricGaussian(rv_continuous):
         
         # numerically integrate asymmetric Gaussian from 0 to +inf, for normalization
         integ = quad(func=AsymmetricGaussian._asymm_gauss_forquad, 
-                      a=0, b=np.inf, 
+                      a=0, b=1e5, 
                       args=(mean[0], unc_minus[0], unc_plus[0]))
         integ_norm = 1 / integ[0]
 

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -81,7 +81,7 @@ class AsymmetricGaussian(rv_continuous):
         
         # numerically integrate asymmetric Gaussian from 0 to +inf, for normalization
         integ = quad(func=AsymmetricGaussian._asymm_gauss_forquad, 
-                      a=0, b=1e4, 
+                      a=0, b=np.inf, 
                       args=(mean[0], unc_minus[0], unc_plus[0]))
         integ_norm = 1 / integ[0]
 

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -81,7 +81,7 @@ class AsymmetricGaussian(rv_continuous):
         
         # numerically integrate asymmetric Gaussian from 0 to +inf, for normalization
         integ = quad(func=AsymmetricGaussian._asymm_gauss_forquad, 
-                      a=0, b=1e5, 
+                      a=0, b=1e4, 
                       args=(mean[0], unc_minus[0], unc_plus[0]))
         integ_norm = 1 / integ[0]
 

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -58,7 +58,7 @@ PCC_THRESHOLD = 0.1
 
 # upper / lower bounds on distance for computing normal / asymmetric Gaussian
 # distributions
-D_LIM_LOWER = 1e-5 # -9 Mpc
+D_LIM_LOWER = 1e-5 # 0.00001 Mpc
 D_LIM_UPPER = 1e4  # 10,000 Mpc 
 
 class AsymmetricGaussian(rv_continuous):


### PR DESCRIPTION
Changes:
- Using np.trapezoid or trapz for integrating asymmetric Gaussian to compute normalization
- Computing this integral over a log-spaced array 
- Some helpful warning messages that the bounds of the integral are hard-coded