### PR TITLE
Inconsistent behaviour in candidate_vetting/public_catalogs/utils.create_phot

### DIFF
--- a/candidate_vetting/public_catalogs/util.py
+++ b/candidate_vetting/public_catalogs/util.py
@@ -33,6 +33,10 @@ def create_phot(target, time, fluxdict, source):
 
     Returns True if it was created, false if it already existed
     """
+    if not(("magnitude" in fluxdict.keys() and "error" in fluxdict.keys()) ^ 
+            ("limit" in fluxdict.keys())):
+        raise ValueError("Must pass EITHER a magnitude and associated error "+
+                          "OR a limit, but not both")
     _, created = ReducedDatum.objects.get_or_create(
         timestamp = time,
         value = fluxdict,


### PR DESCRIPTION
When passing a magnitude, associated error on the magnitude, and a limiting magnitude to `create_phot`, the lightcurve on the target page is populated with the magnitude and its error but the photometry table shows whatever value was passed for the limiting magnitude. 

This PR updates `create_phot` so that it raises an exception unless the user provides (via the `fluxdict` argument) both a magnitude and associated error OR a limiting magnitude, but not both. 