### PR TITLE
AGN-nonlocalized event distance scoring

### DIFF
--- a/candidate_vetting/public_catalogs/static_catalogs.py
+++ b/candidate_vetting/public_catalogs/static_catalogs.py
@@ -226,9 +226,20 @@ class Milliquas(StaticCatalog):
             "z_err":"z_err",
             "rmag":"default_mag" # mag col to use for pcc
         }
-
+        
         # then, of course, init the super class
         super().__init__()
+        
+    def to_standardized_catalog(self, df):
+        df = self._standardize_df(df)
+        df["z_neg_err"] = df.z_err
+        df["z_pos_err"] = df.z_err
+        df["lumdist"] = cosmo.luminosity_distance(df.z).to(u.Mpc).value
+        df["lumdist_err"] = cosmo.luminosity_distance(df.z_err).to(u.Mpc).value
+        df["lumdist_neg_err"] = df.lumdist_err
+        df["lumdist_pos_err"] = df.lumdist_err
+        return df
+
 
 class Ps1(StaticCatalog):
     catalog_model = Ps1Q3C

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -204,7 +204,7 @@ def _save_host_galaxy_df(df, target):
 
 def _save_associated_agn_df(df, target):
 
-    # first delete the host galaxy key for this target if it already exists
+    # first delete the associated AGN key for this target if it already exists
     if TargetExtra.objects.filter(target_id=target.id, key="Associated AGN").exists():
         TargetExtra.objects.filter(target_id=target.id, key="Associated AGN").delete()
     
@@ -562,7 +562,7 @@ def agn_distance_match(
 
     Returns
     -------
-    host_df : pd.DataFrame
+    agn_df : pd.DataFrame
         Dataframe containing information on AGN(s), with added integrated 
         joint probability
 

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -523,7 +523,7 @@ def associate_agn_2d(target_id:int, radius:float=2):
     if len(res) > 0: # when no matches, nothing to concatenate
         df = pd.concat(res).reset_index(drop=True)
     else: # return an empty dataframe
-        return df
+        return pd.DataFrame({})
 
     # put any more cleaning up / filtering here; none for now
     ret_df = df.copy()


### PR DESCRIPTION
Implements functionality for scoring candidates which crossmatch with AGN based on the distance of the AGN. Analogous to our host distance matching. 

Changes:
- Standardization of Milliquas catalog, including calculating the luminosity distance and uncertainties associated with a Milliquas redshift, in `candidate_vetting.public_catalogs.static_catalogs`. Makes these catalogues look more like our other galaxy catalogues. 
- Fleshed out docstrings for `candidate_vetting.vet.host_distance_match`
- Updates to `candidate_vetting.vet.associate_agn_2d` to handle and return dataframes, akin to `host_association`
- New function `candidate_vetting.vet.agn_distance_match`, akin to `host_distance_match`

Closes #52 