### PR TITLE
Incorporate AGN scoring in kilonova vetting

### DIFF
--- a/custom_code/templatetags/event_candidate_extras.py
+++ b/custom_code/templatetags/event_candidate_extras.py
@@ -120,8 +120,10 @@ def display_score_details(target_id):
     res = {}
     keymap = dict(
         skymap_score = ("2D Localization Score", _float_format),
-        ps_score = ("Point Source Score (1 or 0)", _bool_format),
         host_distance_score = ("3D Association Score", _float_format),
+        ps_score = ("Point Source Score (1 or 0)", _bool_format),
+        mpc_score = ("Minor Planet Center Score (1 or 0)", _bool_format),
+        agn_score = ("AGN Score (1 or 0 except for AGN flares)", _float_format),
         phot_peak_lum = ("Maximum Luminosity", partial(_sci_format, unit="erg/s")),
         phot_peak_time = ("Time of Maximum Light Curve", partial(_float_format, unit="days")),
         phot_decay_rate = ("Light Curve Slope (positive is brightening)", partial(_float_format, unit="mag/day"))


### PR DESCRIPTION
This makes the following changes to `candidate_vetting.vet_bns`: 
* We search for 2D-associated AGN. If any, AGN score is 0. If none, AGN score is 1. 
* Scoring procedure slightly reordered: point source, then AGN, then minor planet. 
* Scoring no longer terminates when an associated point source is found. Instead, we look for both point sources and AGN, record scores (whether 1 or 0), and then check if either is 0. If either is 0, then we terminate. 

And to `custom_code.templatetags.event_candidate_extras`, in the `display_score_details()` function:
- AGN score now displayed
- MPC score now displayed

This resolves issue #53 .