### PR TITLE
Generalize vet_bns to KNe-in-SNe and super-KNe

### DIFF
--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -43,7 +43,8 @@ PARAM_RANGES = dict(
     lum_max = [0*u.erg/u.s, 1e43*u.erg/u.s],
     peak_time = [0, 4],
     decay_rate = [-np.inf, -0.1],
-    max_predets = 3
+    max_predets = 3,
+    t_pre = 0,
 )
 FILTER_PRIORITY_ORDER = ["r", "g", "V", "R", "G"]
 PHOT_SCORE_MIN = 0.1
@@ -211,8 +212,10 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
     if decay_rate is not None:
         update_score_factor(event_candidate, "phot_decay_rate", decay_rate)
 
-    # check for *reliable* predetections
-    prephot = _get_pre_disc_phot(target.id, nonlocalized_event)
+    # check for *reliable* predetections before time t_pre
+    prephot = _get_pre_disc_phot(target.id,
+                                 nonlocalized_event, 
+                                 PARAM_RANGES["t_pre"])
     predet_score = 1
     if prephot is not None and len(prephot):
         try:

--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -1,5 +1,6 @@
 """
-The "pipeline" to vet BNS nonlocalized events
+The "pipeline" to vet candidate counterparts to nonlocalized events based on 
+their resemblance to kilonovae.
 """
 import logging
 from typing import Optional

--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -76,10 +76,10 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
     )
     # then, assign score based on AGN association
     if len(agn_df) != 0:
-        agn_assoc_score = 0 # for BNS, association with an AGN is bad
+        agn_assoc_score = 0 # association with an AGN is bad
     else:
         agn_assoc_score = 1 
-    agn_score = agn_assoc_score # for BNS, don't bother with 3D AGN scoring
+    agn_score = agn_assoc_score # don't bother with 3D AGN scoring
     update_score_factor(event_candidate, "agn_score", agn_score)
     
     ## if either point source or AGN score is 0, end it here

--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -17,15 +17,14 @@ from .vet import (
     associate_agn_2d,
     agn_distance_match,
     update_score_factor,
-    _distance_at_healpix
 )
 from .vet_phot import (
-    compute_peak_lum,
-    estimate_max_find_decay_rate,
-    standardize_filter_names,
     _get_post_disc_phot,
+    _score_phot,
     _get_pre_disc_phot,
-    get_predetection_stats
+    get_predetection_stats,
+    PHOT_SCORE_MIN,
+    PREDETECTION_SNR_THRESHOLD
 )
 from trove_mpc import Transient
 
@@ -46,66 +45,7 @@ PARAM_RANGES = dict(
     max_predets = 3,
     t_pre = 0,
 )
-FILTER_PRIORITY_ORDER = ["r", "g", "V", "R", "G"]
-PHOT_SCORE_MIN = 0.1
-PREDETECTION_SNR_THRESHOLD = 5 # require a S/N of 5 for a predetection to be considered real
 
-def _score_phot(allphot, target, nonlocalized_event, filt=None):
-    if allphot is None: # this is if there is no photometry
-        return 1, None, None, None, None, None
-    
-    phot = allphot[~allphot.upperlimit]
-    if not len(phot):
-        # then there is no photometry for this object and we're done!
-        return 1, None, None, None, None, None
-    
-    # find the filter we will use for the photometry analysis
-    if filt is None:
-        for filt in FILTER_PRIORITY_ORDER:
-            if filt in phot["filter"].values:
-                break
-        else:
-            # This target does not have any photometry with the correct filters!
-            # so we return a score of 1
-            return 1, None, None, None, None, None
-
-    # now filter down the photometry
-    if isinstance(filt, list) or isinstance(filt, set):
-        phot = phot[phot["filter"].isin(filt)]
-    elif filt != "all" and isinstance(filt, str):
-        phot = phot[phot["filter"] == filt]
-    
-    # if we've made it to this point we have at least one detection so
-    # we can calculate the luminosity
-    dist, dist_err = _distance_at_healpix(nonlocalized_event.event_id, target.id)
-    lum = compute_peak_lum(phot.mag, phot.magerr, phot["filter"].tolist(), dist*u.Mpc)
-
-    phot_score = 1
-    if lum is not None and (
-            lum < PARAM_RANGES["lum_max"][0] or lum > PARAM_RANGES["lum_max"][1]
-    ):
-        phot_score *= PHOT_SCORE_MIN
-
-    # then we can only do the next stuff if there is more than one photometry point
-    # at this filter
-    if len(phot) > 1: # has to be at least 2 points to fit the powerlaw        
-        # find the maximum and decay rate
-        _model,_best_fit_params,max_time,decay_rate = estimate_max_find_decay_rate(
-            phot.dt,
-            phot.mag,
-            phot.magerr
-        )
-        
-        # check if these are within the appropriate ranges
-        if max_time < PARAM_RANGES["peak_time"][0] or max_time > PARAM_RANGES["peak_time"][1]:
-            phot_score *= PHOT_SCORE_MIN
-        
-        if decay_rate > PARAM_RANGES["decay_rate"][1]: # if it's greater than the max
-            phot_score *= PHOT_SCORE_MIN
-
-        return phot_score, lum, max_time, decay_rate, _model, _best_fit_params
-    
-    return phot_score, lum, None, None, None, None
 
 def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
 
@@ -203,6 +143,7 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
         allphot=allphot,
         target = target,
         nonlocalized_event = nonlocalized_event,
+        param_ranges=PARAM_RANGES,
         filt = ["g", "r", "i", "o", "c"] # use the common optical filters
     )
     if lum is not None:

--- a/candidate_vetting/vet_kn_in_sn.py
+++ b/candidate_vetting/vet_kn_in_sn.py
@@ -1,0 +1,174 @@
+"""
+The "pipeline" to vet candidate counterparts to nonlocalized events based on 
+their resemblance to kilonovae-in-supernovae.
+"""
+import logging
+from typing import Optional
+from astropy.time import Time
+from astropy import units as u
+import pandas as pd
+import numpy as np
+
+from .vet import (
+    skymap_association,
+    point_source_association,
+    host_association,
+    host_distance_match,
+    associate_agn_2d,
+    agn_distance_match,
+    update_score_factor,
+)
+from .vet_phot import (
+    _get_post_disc_phot,
+    _score_phot,
+    _get_pre_disc_phot,
+    get_predetection_stats,
+    PHOT_SCORE_MIN,
+    PREDETECTION_SNR_THRESHOLD
+)
+from trove_mpc import Transient
+
+from trove_targets.models import Target
+from tom_dataproducts.models import ReducedDatum
+from tom_nonlocalizedevents.models import (
+    EventCandidate,
+    NonLocalizedEvent,
+    EventSequence
+)
+
+logger = logging.getLogger(__name__)
+
+PARAM_RANGES = dict(
+    lum_max = [5e41*u.erg/u.s, 1e44*u.erg/u.s],
+    peak_time = [0, 35],
+    decay_rate = [-0.1, np.inf],
+    max_predets = 3,
+    t_pre = -0.1,
+)
+
+
+def vet_kn_in_sn(target_id:int, nonlocalized_event_name:Optional[str]=None):
+
+    # get the correct EventCandidate object for this target_id and nonlocalized event
+    nonlocalized_event = NonLocalizedEvent.objects.get(
+        event_id=nonlocalized_event_name
+    )
+    event_candidate = EventCandidate.objects.get(
+        nonlocalizedevent_id = nonlocalized_event.id,
+        target_id = target_id
+    )
+    
+    ## check skymap association
+    skymap_score = skymap_association(nonlocalized_event_name, target_id)
+    update_score_factor(event_candidate, "skymap_score", skymap_score)
+    if skymap_score < 1e-2:
+        return 
+
+    ## run the point source checker
+    ps_score = point_source_association(target_id)
+    update_score_factor(event_candidate, "ps_score", ps_score)
+    
+    ## AGN score
+    # search for an AGN associated with the target
+    agn_df = associate_agn_2d(
+        target_id, 
+        radius=2 # 2 arcseconds
+    )
+    # then, assign score based on AGN association
+    if len(agn_df) != 0:
+        agn_assoc_score = 0 # association with an AGN is bad
+    else:
+        agn_assoc_score = 1 
+    agn_score = agn_assoc_score # don't bother with 3D AGN scoring
+    update_score_factor(event_candidate, "agn_score", agn_score)
+    
+    ## if either point source or AGN score is 0, end it here
+    if ps_score == 0 or agn_score == 0:
+        return
+    
+    ## run the minor planet checker
+    target = Target.objects.filter(id=target_id)[0]
+    phot = ReducedDatum.objects.filter(
+        target_id=target_id,
+        data_type="photometry",
+        value__magnitude__isnull=False
+    )
+    if phot.exists():
+        latest_det = phot.latest()
+        date = Time(latest_det.timestamp).mjd
+        t = Transient(target.ra, target.dec)
+        mpc_match = t.minor_planet_match(date)
+    else:
+        logger.warn("This candidate has no photometry, skipping MPC!")
+        mpc_match = None
+
+    # update the score factor information
+    if mpc_match is not None:
+        update_score_factor(event_candidate, "mpc_match_name", mpc_match.match_name)
+        update_score_factor(event_candidate, "mpc_match_sep", mpc_match.distance)
+        update_score_factor(event_candidate, "mpc_match_date", latest_det.timestamp)
+        mpc_score = 0
+        update_score_factor(event_candidate, "mpc_score", mpc_score)
+        return
+    else:    
+        mpc_score = 1
+        update_score_factor(event_candidate, "mpc_score", mpc_score)
+
+    ## distance score
+    # do the Pcc analysis and find a host
+    host_df = host_association(
+        target_id,
+        radius = 5*60 # 5*60 arcseconds
+    )
+    if len(host_df) != 0:
+        # then run the distance comparison for each of these hosts
+        host_df = host_distance_match(
+            host_df,
+            target_id,
+            nonlocalized_event_name
+        )
+
+        # choose the maximum score out of the top 10 best hosts
+        host_score = host_df.dist_norm_joint_prob.max()
+        update_score_factor(event_candidate, "host_distance_score", host_score)
+
+    else:
+        # if no hosts are found we don't want to bias the final score if the host
+        # is just too far
+        host_score = 1
+        
+    ## photometry scoring
+    allphot = _get_post_disc_phot(target_id=target_id, nonlocalized_event=nonlocalized_event)
+    phot_score, lum, max_time, decay_rate, _, _ = _score_phot(
+        allphot=allphot,
+        target = target,
+        nonlocalized_event = nonlocalized_event,
+        param_ranges=PARAM_RANGES,
+        filt = ["g", "r", "i", "o", "c"] # use the common optical filters
+    )
+    if lum is not None:
+        update_score_factor(event_candidate, "phot_peak_lum", lum.value)
+    if max_time is not None:
+        update_score_factor(event_candidate, "phot_peak_time", max_time)
+    if decay_rate is not None:
+        update_score_factor(event_candidate, "phot_decay_rate", decay_rate)
+
+    # check for *reliable* predetections before time t_pre
+    prephot = _get_pre_disc_phot(target.id,
+                                 nonlocalized_event, 
+                                 PARAM_RANGES["t_pre"])
+    predet_score = 1
+    if prephot is not None and len(prephot):
+        try:
+            n_predets, _ = get_predetection_stats(
+                prephot.mjd.values,
+                prephot.magerr.values,
+                window_size=5, # +/-5 day window size
+                det_snr_thresh=PREDETECTION_SNR_THRESHOLD
+            )
+        except ValueError:
+            n_predets = [0] # this ValueError only happens when there aren't any predets
+        if any(v >= PARAM_RANGES["max_predets"] for v in n_predets):
+            predet_score = PHOT_SCORE_MIN
+            update_score_factor(event_candidate, "predetection_score", predet_score)
+

--- a/candidate_vetting/vet_kn_in_sn.py
+++ b/candidate_vetting/vet_kn_in_sn.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 PARAM_RANGES = dict(
     lum_max = [5e41*u.erg/u.s, 1e44*u.erg/u.s],
     peak_time = [0, 35],
-    decay_rate = [-0.1, np.inf],
+    decay_rate = [-0.1, 2.0],
     max_predets = 3,
     t_pre = -0.1,
 )

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -19,6 +19,14 @@ from trove_targets.models import Target
 from candidate_vetting.public_catalogs.phot_catalogs import TNS_Phot
 from candidate_vetting.tasks import async_atlas_query
 
+from .vet import _distance_at_healpix
+
+
+FILTER_PRIORITY_ORDER = ["r", "g", "V", "R", "G"]
+PHOT_SCORE_MIN = 0.1
+PREDETECTION_SNR_THRESHOLD = 5 # require a S/N of 5 for a predetection to be considered real
+
+
 def _powerlaw(x, a, y0):
     """
     Powerlaw that returns a logarithmic y value
@@ -435,3 +443,62 @@ def find_public_phot(
                 days_ago
             ) # this min ensures we never query more than days_ago_max
         )
+
+def _score_phot(allphot, target, nonlocalized_event, 
+                param_ranges,
+                filt=None):
+    if allphot is None: # this is if there is no photometry
+        return 1, None, None, None, None, None
+    
+    phot = allphot[~allphot.upperlimit]
+    if not len(phot):
+        # then there is no photometry for this object and we're done!
+        return 1, None, None, None, None, None
+    
+    # find the filter we will use for the photometry analysis
+    if filt is None:
+        for filt in FILTER_PRIORITY_ORDER:
+            if filt in phot["filter"].values:
+                break
+        else:
+            # This target does not have any photometry with the correct filters!
+            # so we return a score of 1
+            return 1, None, None, None, None, None
+
+    # now filter down the photometry
+    if isinstance(filt, list) or isinstance(filt, set):
+        phot = phot[phot["filter"].isin(filt)]
+    elif filt != "all" and isinstance(filt, str):
+        phot = phot[phot["filter"] == filt]
+    
+    # if we've made it to this point we have at least one detection so
+    # we can calculate the luminosity
+    dist, dist_err = _distance_at_healpix(nonlocalized_event.event_id, target.id)
+    lum = compute_peak_lum(phot.mag, phot.magerr, phot["filter"].tolist(), dist*u.Mpc)
+
+    phot_score = 1
+    if lum is not None and (
+            lum < param_ranges["lum_max"][0] or lum > param_ranges["lum_max"][1]
+    ):
+        phot_score *= PHOT_SCORE_MIN
+
+    # then we can only do the next stuff if there is more than one photometry point
+    # at this filter
+    if len(phot) > 1: # has to be at least 2 points to fit the powerlaw        
+        # find the maximum and decay rate
+        _model,_best_fit_params,max_time,decay_rate = estimate_max_find_decay_rate(
+            phot.dt,
+            phot.mag,
+            phot.magerr
+        )
+        
+        # check if these are within the appropriate ranges
+        if max_time < param_ranges["peak_time"][0] or max_time > param_ranges["peak_time"][1]:
+            phot_score *= PHOT_SCORE_MIN
+        
+        if decay_rate > param_ranges["decay_rate"][1]: # if it's greater than the max
+            phot_score *= PHOT_SCORE_MIN
+
+        return phot_score, lum, max_time, decay_rate, _model, _best_fit_params
+    
+    return phot_score, lum, None, None, None, None

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -496,7 +496,7 @@ def _score_phot(allphot, target, nonlocalized_event,
         if max_time < param_ranges["peak_time"][0] or max_time > param_ranges["peak_time"][1]:
             phot_score *= PHOT_SCORE_MIN
         
-        if decay_rate > param_ranges["decay_rate"][1]: # if it's greater than the max
+        if decay_rate < param_ranges["decay_rate"][0] or decay_rate > param_ranges["decay_rate"][1]:
             phot_score *= PHOT_SCORE_MIN
 
         return phot_score, lum, max_time, decay_rate, _model, _best_fit_params

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -126,12 +126,13 @@ def _get_post_disc_phot(
     
 def _get_pre_disc_phot(
         target_id:int,
-        nonlocalized_event:NonLocalizedEvent
+        nonlocalized_event:NonLocalizedEvent,
+        t_pre:float=0,
 ) -> pd.DataFrame:
     photdf = _get_phot(target_id, nonlocalized_event)
     if not len(photdf):
         return
-    phot_pre_disc = photdf[photdf.dt < 0]
+    phot_pre_disc = photdf[photdf.dt < t_pre]
     return phot_pre_disc
 
 def _get_window_stats(min_idx, max_idx, isdet):

--- a/candidate_vetting/vet_super_kn.py
+++ b/candidate_vetting/vet_super_kn.py
@@ -1,0 +1,173 @@
+"""
+The "pipeline" to vet candidate counterparts to nonlocalized events based on 
+their resemblance to super-kilonovae.
+"""
+import logging
+from typing import Optional
+from astropy.time import Time
+from astropy import units as u
+import pandas as pd
+import numpy as np
+
+from .vet import (
+    skymap_association,
+    point_source_association,
+    host_association,
+    host_distance_match,
+    associate_agn_2d,
+    agn_distance_match,
+    update_score_factor,
+)
+from .vet_phot import (
+    _get_post_disc_phot,
+    _score_phot,
+    _get_pre_disc_phot,
+    get_predetection_stats,
+    PHOT_SCORE_MIN,
+    PREDETECTION_SNR_THRESHOLD
+)
+from trove_mpc import Transient
+
+from trove_targets.models import Target
+from tom_dataproducts.models import ReducedDatum
+from tom_nonlocalizedevents.models import (
+    EventCandidate,
+    NonLocalizedEvent,
+    EventSequence
+)
+
+logger = logging.getLogger(__name__)
+
+PARAM_RANGES = dict(
+    lum_max = [1e41*u.erg/u.s, 1e43*u.erg/u.s],
+    peak_time = [10, 70],
+    decay_rate = [-np.inf, np.inf],
+    max_predets = 3,
+    t_pre = -0.5,
+)
+
+
+def vet_super_kn(target_id:int, nonlocalized_event_name:Optional[str]=None):
+
+    # get the correct EventCandidate object for this target_id and nonlocalized event
+    nonlocalized_event = NonLocalizedEvent.objects.get(
+        event_id=nonlocalized_event_name
+    )
+    event_candidate = EventCandidate.objects.get(
+        nonlocalizedevent_id = nonlocalized_event.id,
+        target_id = target_id
+    )
+    
+    ## check skymap association
+    skymap_score = skymap_association(nonlocalized_event_name, target_id)
+    update_score_factor(event_candidate, "skymap_score", skymap_score)
+    if skymap_score < 1e-2:
+        return 
+
+    ## run the point source checker
+    ps_score = point_source_association(target_id)
+    update_score_factor(event_candidate, "ps_score", ps_score)
+    
+    ## AGN score
+    # search for an AGN associated with the target
+    agn_df = associate_agn_2d(
+        target_id, 
+        radius=2 # 2 arcseconds
+    )
+    # then, assign score based on AGN association
+    if len(agn_df) != 0:
+        agn_assoc_score = 0 # association with an AGN is bad
+    else:
+        agn_assoc_score = 1 
+    agn_score = agn_assoc_score # don't bother with 3D AGN scoring
+    update_score_factor(event_candidate, "agn_score", agn_score)
+    
+    ## if either point source or AGN score is 0, end it here
+    if ps_score == 0 or agn_score == 0:
+        return
+    
+    ## run the minor planet checker
+    target = Target.objects.filter(id=target_id)[0]
+    phot = ReducedDatum.objects.filter(
+        target_id=target_id,
+        data_type="photometry",
+        value__magnitude__isnull=False
+    )
+    if phot.exists():
+        latest_det = phot.latest()
+        date = Time(latest_det.timestamp).mjd
+        t = Transient(target.ra, target.dec)
+        mpc_match = t.minor_planet_match(date)
+    else:
+        logger.warn("This candidate has no photometry, skipping MPC!")
+        mpc_match = None
+
+    # update the score factor information
+    if mpc_match is not None:
+        update_score_factor(event_candidate, "mpc_match_name", mpc_match.match_name)
+        update_score_factor(event_candidate, "mpc_match_sep", mpc_match.distance)
+        update_score_factor(event_candidate, "mpc_match_date", latest_det.timestamp)
+        mpc_score = 0
+        update_score_factor(event_candidate, "mpc_score", mpc_score)
+        return
+    else:    
+        mpc_score = 1
+        update_score_factor(event_candidate, "mpc_score", mpc_score)
+
+    ## distance score
+    # do the Pcc analysis and find a host
+    host_df = host_association(
+        target_id,
+        radius = 5*60 # 5*60 arcseconds
+    )
+    if len(host_df) != 0:
+        # then run the distance comparison for each of these hosts
+        host_df = host_distance_match(
+            host_df,
+            target_id,
+            nonlocalized_event_name
+        )
+
+        # choose the maximum score out of the top 10 best hosts
+        host_score = host_df.dist_norm_joint_prob.max()
+        update_score_factor(event_candidate, "host_distance_score", host_score)
+
+    else:
+        # if no hosts are found we don't want to bias the final score if the host
+        # is just too far
+        host_score = 1
+        
+    ## photometry scoring
+    allphot = _get_post_disc_phot(target_id=target_id, nonlocalized_event=nonlocalized_event)
+    phot_score, lum, max_time, decay_rate, _, _ = _score_phot(
+        allphot=allphot,
+        target = target,
+        nonlocalized_event = nonlocalized_event,
+        param_ranges=PARAM_RANGES,
+        filt = ["g", "r", "i", "o", "c"] # use the common optical filters
+    )
+    if lum is not None:
+        update_score_factor(event_candidate, "phot_peak_lum", lum.value)
+    if max_time is not None:
+        update_score_factor(event_candidate, "phot_peak_time", max_time)
+    if decay_rate is not None:
+        update_score_factor(event_candidate, "phot_decay_rate", decay_rate)
+
+    # check for *reliable* predetections before time t_pre
+    prephot = _get_pre_disc_phot(target.id,
+                                 nonlocalized_event, 
+                                 PARAM_RANGES["t_pre"])
+    predet_score = 1
+    if prephot is not None and len(prephot):
+        try:
+            n_predets, _ = get_predetection_stats(
+                prephot.mjd.values,
+                prephot.magerr.values,
+                window_size=5, # +/-5 day window size
+                det_snr_thresh=PREDETECTION_SNR_THRESHOLD
+            )
+        except ValueError:
+            n_predets = [0] # this ValueError only happens when there aren't any predets
+        if any(v >= PARAM_RANGES["max_predets"] for v in n_predets):
+            predet_score = PHOT_SCORE_MIN
+            update_score_factor(event_candidate, "predetection_score", predet_score)

--- a/candidate_vetting/views.py
+++ b/candidate_vetting/views.py
@@ -10,6 +10,8 @@ from django.http import HttpResponseRedirect
 
 from trove_targets.models import Target
 from candidate_vetting.vet_bns import vet_bns
+from candidate_vetting.vet_kn_in_sn import vet_kn_in_sn
+from candidate_vetting.vet_super_kn import vet_super_kn
 from candidate_vetting.vet_phot import find_public_phot
 
 import requests
@@ -20,7 +22,8 @@ class TargetVettingView(LoginRequiredMixin, RedirectView):
     """
     def get(self, request, *args, **kwargs):
         """
-        Method that handles the GET requests for this view. Calls the kilonova vetting code.
+        Method that handles the GET requests for this view. Calls the vetting 
+        code for different transients.
         """        
         target = Target.objects.get(pk=kwargs['pk'])
 
@@ -42,6 +45,8 @@ class TargetVettingView(LoginRequiredMixin, RedirectView):
 
         # then run the vetting
         vet_bns(target.id, nonlocalized_event_name)
+        vet_kn_in_sn(target.id, nonlocalized_event_name)
+        vet_super_kn(target.id, nonlocalized_event_name)
         
         return HttpResponseRedirect(self.get_redirect_url())
 

--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -4,8 +4,12 @@ import numpy as np
 from tom_targets.models import TargetExtra
 from tom_nonlocalizedevents.models import NonLocalizedEvent
 from tom_dataproducts.models import ReducedDatum
-from candidate_vetting.vet_bns import vet_bns
+
 from candidate_vetting.vet_phot import find_public_phot
+from candidate_vetting.vet_bns import vet_bns
+from candidate_vetting.vet_kn_in_sn import vet_kn_in_sn
+from candidate_vetting.vet_super_kn import vet_super_kn
+
 from candidate_vetting.public_catalogs.phot_catalogs import TNS_Phot
 from custom_code.healpix_utils import create_candidates_from_targets
 from custom_code.templatetags.skymap_extras import get_preferred_localization
@@ -123,10 +127,12 @@ def target_post_save(target, created=True, lookback_days_nle=7, lookback_days_ob
         )
         
         # TODO: add a check for the type of non-localized event
-        #       For now we are just always running the BNS vetting
+        #       For now we are just always all types of vetting
         if len(new_candidates):
             for cand in new_candidates:
                 vet_bns(cand.target.id, cand.nonlocalizedevent.event_id)
+                vet_kn_in_sn(cand.target.id, cand.nonlocalizedevent.event_id)
+                vet_super_kn(cand.target.id, cand.nonlocalizedevent.event_id)
         else:
             messages.append("Could not run vetting on this target because there are no non-localized events associated with it!")
             

--- a/custom_code/templatetags/event_candidate_extras.py
+++ b/custom_code/templatetags/event_candidate_extras.py
@@ -145,7 +145,7 @@ def display_score_details(target_id):
         host_distance_score = ("3D Association Score", _float_format),
         ps_score = ("Point Source Score (1 or 0)", _bool_format),
         mpc_score = ("Minor Planet Center Score (1 or 0)", _bool_format),
-        agn_score = ("AGN Score (1 or 0 except for AGN flares)", _float_format),
+        agn_score = ("AGN Score (1 or 0)", _bool_format),
         phot_peak_lum = ("Maximum Luminosity", partial(_sci_format, unit="erg/s")),
         phot_peak_time = ("Time of Maximum Light Curve", partial(_float_format, unit="days")),
         phot_decay_rate = ("Light Curve Slope (positive is brightening)", partial(_float_format, unit="mag/day"))

--- a/custom_code/templatetags/event_candidate_extras.py
+++ b/custom_code/templatetags/event_candidate_extras.py
@@ -12,10 +12,9 @@ from django.db.models.functions import Cast
 from tom_nonlocalizedevents.models import EventCandidate, NonLocalizedEvent
 from trove_targets.models import Target
 from candidate_vetting.models import ScoreFactor
-from candidate_vetting.vet_bns import (
-    PARAM_RANGES as KN_PARAM_RANGES,
-    PHOT_SCORE_MIN as KN_PHOT_SCORE_MIN
-)
+from candidate_vetting.vet_bns import PARAM_RANGES as KN_PARAM_RANGES
+from candidate_vetting.vet_phot import PHOT_SCORE_MIN as KN_PHOT_SCORE_MIN
+
 from astropy.units import Quantity
 
 register = template.Library()

--- a/custom_code/templatetags/event_candidate_extras.py
+++ b/custom_code/templatetags/event_candidate_extras.py
@@ -12,10 +12,23 @@ from django.db.models.functions import Cast
 from tom_nonlocalizedevents.models import EventCandidate, NonLocalizedEvent
 from trove_targets.models import Target
 from candidate_vetting.models import ScoreFactor
+
+from candidate_vetting.vet_phot import PHOT_SCORE_MIN
 from candidate_vetting.vet_bns import PARAM_RANGES as KN_PARAM_RANGES
-from candidate_vetting.vet_phot import PHOT_SCORE_MIN as KN_PHOT_SCORE_MIN
+from candidate_vetting.vet_kn_in_sn import PARAM_RANGES as KN_IN_SN_PARAM_RANGES
+from candidate_vetting.vet_super_kn import PARAM_RANGES as SUPER_KN_PARAM_RANGES
+
 
 from astropy.units import Quantity
+
+# map imported parameter ranges to transients
+TRANSIENTS = ["KN",
+              "KN-in-SN",
+              "super-KN"]
+DICT_TRANSIENTS_PARAM_RANGES = {
+    "KN":KN_PARAM_RANGES,
+    "KN-in-SN":KN_IN_SN_PARAM_RANGES,
+    "super-KN":SUPER_KN_PARAM_RANGES}
 
 register = template.Library()
 
@@ -28,59 +41,69 @@ def get_event_candidate_scores(event_candidates, *subscore_names):
 
     ecs_out = []
     for ec in event_candidates:
+        # set ec.score to be a dictionary mapping transient : score
+        ec.score = {}
 
-        # first get all the subscores for this object
-        subscores = ScoreFactor.objects.filter(
-            event_candidate = ec,
-            key__in = subscore_names
-        ).annotate(
-            value_float = Cast("value", FloatField())
-        )
-
-        
         # some of the keys in ScoreFactor are really just calculated values
         # where the score depends on the type of non-localized event. So we need to convert
         # these to scores.
-        # I'm writing this just for KN for now, but we can modify as needed!
         val_not_score_keys = {
             "phot_peak_lum":"lum_max",
             "phot_peak_time":"peak_time",
             "phot_decay_rate":"decay_rate"
         }
-        phot_score = 1
-        subscore_keys = subscores.values_list("key", flat=True)        
-        for subscore_key, param_range_key in val_not_score_keys.items():
-            if subscore_key in subscore_names and subscore_key in subscore_keys:
-                val = subscores.get(
-                    key = subscore_key
-                ).value_float
-
-                val_max = max(KN_PARAM_RANGES[param_range_key])
-                val_min = min(KN_PARAM_RANGES[param_range_key])
-                if isinstance(val_min, Quantity):
-                    val_min = val_min.value
-                if isinstance(val_max, Quantity):
-                    val_max = val_max.value
-                
-                if val < val_min or val > val_max:
-                    phot_score *= KN_PHOT_SCORE_MIN
-             
+        for transient in TRANSIENTS: 
+            # allowed parameter ranges for given transient
+            param_ranges = DICT_TRANSIENTS_PARAM_RANGES[transient]
             
-        subscores = subscores.exclude(
-            key__in = list(val_not_score_keys.keys())
-        ) # this removes those rows from the queryset
-        
-        # now we can compute the score just using multiplication
-        subscore_list = list(
-            subscores.values_list("value_float", flat=True)
-        )
-        subscore_list.append(phot_score)
-
-        # save the score to a temporary field in the EventCandidate object
-        ec.score = math.prod(subscore_list) # multiply the subscores
+            phot_score = 1 # reset to 1.0 for each transient
+            
+            # get all 'subscores' (sometimes actually calculated values)
+            # for object; need to re-do this per transient because of step 
+            # below where we exclude certain scores from the queryset
+            subscores = ScoreFactor.objects.filter(
+                event_candidate = ec,
+                key__in = subscore_names
+            ).annotate(
+                value_float = Cast("value", FloatField())
+            )
+            
+            # iterate though subscores/values which will determine subscores
+            subscore_keys = subscores.values_list("key", flat=True)
+            for subscore_key, param_range_key in val_not_score_keys.items():
+                if subscore_key in subscore_names and subscore_key in subscore_keys:
+                    val = subscores.get(
+                        key = subscore_key
+                    ).value_float
+                    # check if within limits
+                    val_max = max(param_ranges[param_range_key])
+                    val_min = min(param_ranges[param_range_key])
+                    if isinstance(val_min, Quantity):
+                        val_min = val_min.value
+                    if isinstance(val_max, Quantity):
+                        val_max = val_max.value
+                    
+                    if val < val_min or val > val_max:
+                        # multiply photometry score by PHOT_SCORE_MIN
+                        phot_score *= PHOT_SCORE_MIN 
+                
+            subscores = subscores.exclude(
+                key__in = list(val_not_score_keys.keys())
+            ) # this removes those rows from the queryset
+            
+            # now we can compute the score just using multiplication
+            subscore_list = list(
+                subscores.values_list("value_float", flat=True)
+            )
+            subscore_list.append(phot_score)
+    
+            # save the score to a temporary field (dictionary) in the 
+            # EventCandidate object
+            ec.score[transient] = math.prod(subscore_list) # multiply the subscores
         ecs_out.append(ec)
-        
-    return sorted(ecs_out, reverse=True, key = lambda x : x.score)
+    
+    # sort by kilonova score, for now
+    return sorted(ecs_out, reverse=True, key = lambda x : x.score["KN"])
     
 
 #@register.inclusion_tag('tom_targets/partials/target_data.html', takes_context=True)

--- a/trove_nonlocalizedevents/templates/trove_nonlocalizedevents/candidate_list.html
+++ b/trove_nonlocalizedevents/templates/trove_nonlocalizedevents/candidate_list.html
@@ -36,7 +36,7 @@
           <td><a href="{% url 'nonlocalizedevents:event-detail' candidate.nonlocalizedevent.event_id %}" target="_blank">{{ candidate.nonlocalizedevent.event_id }}</a></td>
           <td>
             {% for transient, score in candidate.score.items %}
-            {{ transient }} {{score|floatformat:3}}<br>
+            {{ transient }} {{score|floatformat:2}}<br>
             {% endfor %}
           </td>
         </tr>

--- a/trove_nonlocalizedevents/templates/trove_nonlocalizedevents/candidate_list.html
+++ b/trove_nonlocalizedevents/templates/trove_nonlocalizedevents/candidate_list.html
@@ -34,7 +34,11 @@
             {% endif %}
           </td>
           <td><a href="{% url 'nonlocalizedevents:event-detail' candidate.nonlocalizedevent.event_id %}" target="_blank">{{ candidate.nonlocalizedevent.event_id }}</a></td>
-          <td>{{ candidate.score|floatformat:2 }}</td>
+          <td>
+            {% for transient, score in candidate.score.items %}
+            {{ transient }} {{score|floatformat:3}}<br>
+            {% endfor %}
+          </td>
         </tr>
         {% empty %}
         <tr>


### PR DESCRIPTION
This is a doozy. I'll try and go through it file by file. 

* Much photometry scoring functionality moved from `candidate_vetting.vet_bns` to `candidate_vetting.vet_phot` . Includes a function and some constants, such that the only constant now defined in `vet_bns` is `PARAM_RANGES`, which describes photometry metrics. 
* When checking for predetection in `vet_phot._get_pre_disc_phot`, can now supply a `t_pre` argument (default 0) which says how long before pre-detection. E.g., if pre-detections at most 0.5 days before merger are fine, you supply `t_pre = -0.5`. `t_pre` now defined in `PARAM_RANGES` for whatever transient.
* `vet_phot._score_phot` now checks decay rates against both the minimum and maximum. 
* New modules `candidate_vetting.vet_kn_in_sn` and `candidate_vetting.vet_super_kn`, analogous to `vet_bns`, but with different parameter ranges. This naming convention makes `vet_bns` somewhat of a misnomer, but not crucial to change it right now and we should have discussions about naming conventions.
* `vet_kn_in_sn` and `vet_super_kn` are now imported and called in the same place as `vet_bns` in ` candidate_vetting.views` and `custom_code.hooks`. Unsure if this was necessary given the way scores are computed in real-time when loading the event candidate page, though. 
* `get_event_candidate_scores()` function in `custom_code.templatetags.event_candidate_extras` now iterates through a series of transients (defined by `TRANSIENTS` constant in the module) mapped to `PARAM_RANGES` imported from each of the `vet_x` modules where x is the transient. It vets each event candidate for each transient, and stores overall scores in a dictionary as the attribute `ec.score` for each event candidate `ec`. Previously, `ec.score` was just a float (overall score for kilonova). 
* `trove_nonlocalizedevents/templates/trove_nonlocalizedevents/candidate_list.html` updated to iterate through this new dictionary of `{transient : overall score}` and display the scores for each transient, with a line break, for each candidate.
