### PR TITLE
Incorporate new distance scoring into `ssm` branch

### DIFF
--- a/candidate_vetting/public_catalogs/catalog.py
+++ b/candidate_vetting/public_catalogs/catalog.py
@@ -75,6 +75,22 @@ class StaticCatalog(Catalog):
         """
 
         self.catalog_type = "static"
+
+        self.colnames = {
+            "name",
+            "ra",
+            "dec",
+            "z",
+            "z_err",
+            "z_neg_err",
+            "z_pos_err",
+            "lumdist",
+            "lumdist_err",
+            "lumdist_neg_err",
+            "lumdist_pos_err",
+            "z_type",
+            "default_mag"
+        }
         
         super().__init__(self.__class__.__name__, verbose=verbose)        
 
@@ -117,7 +133,7 @@ class StaticCatalog(Catalog):
         if not getattr(self, "colmap"):
             raise TypeError("Missing the colmap, can't standardize dataset!")
         df = df.rename(columns=self.colmap)
-        return df[list(self.colmap.values())]
+        return df[list(self.colnames & set(df.columns))]
     
 class PhotCatalog(Catalog):
     def __init__(

--- a/candidate_vetting/public_catalogs/static_catalogs.py
+++ b/candidate_vetting/public_catalogs/static_catalogs.py
@@ -329,8 +329,8 @@ class Milliquas(StaticCatalog):
                 default=Value(1e-3)
             ), # this computes the z_err based on the assumptions outlined in the docs for this catalog
             z_type=Case(
-                When(num_decimal__lte = 2, then=Value("phot")),
-                default=Value("spec")
+                When(num_decimal__lte = 2, then=Value("phot-z")),
+                default=Value("spec-z")
             )
         )
 

--- a/candidate_vetting/public_catalogs/static_catalogs.py
+++ b/candidate_vetting/public_catalogs/static_catalogs.py
@@ -347,6 +347,17 @@ class Milliquas(StaticCatalog):
         # then, of course, init the super class
         super().__init__()
 
+    def to_standardized_catalog(self, df):
+        df = self._standardize_df(df)
+        df["z_neg_err"] = df.z_err
+        df["z_pos_err"] = df.z_err
+        df["lumdist"] = cosmo.luminosity_distance(df.z).to(u.Mpc).value
+        df["lumdist_err"] = cosmo.luminosity_distance(df.z_err).to(u.Mpc).value
+        df["lumdist_neg_err"] = df.lumdist_err
+        df["lumdist_pos_err"] = df.lumdist_err
+        df["z_type"] = "spec-z"
+        return df
+        
 class Ps1(StaticCatalog):
     catalog_model = Ps1Q3C
     colmap = {

--- a/candidate_vetting/public_catalogs/static_catalogs.py
+++ b/candidate_vetting/public_catalogs/static_catalogs.py
@@ -329,7 +329,7 @@ class Milliquas(StaticCatalog):
                 default=Value(1e-3)
             ), # this computes the z_err based on the assumptions outlined in the docs for this catalog
             z_type=Case(
-                When(num_decimal__lte = 2, then=Value("phot-z")),
+                When(num_decimal__lte = 2, then=Value("photo-z")),
                 default=Value("spec-z")
             )
         )

--- a/candidate_vetting/public_catalogs/static_catalogs.py
+++ b/candidate_vetting/public_catalogs/static_catalogs.py
@@ -3,6 +3,7 @@ Define the static catalogs for querying
 """
 from astropy import units as u
 import pandas as pd
+import numpy as np
 
 from django.db.models import F, Q, Func, Value, IntegerField, Case, When, CharField
 from django.db.models.functions import Cast
@@ -173,9 +174,7 @@ class GladePlus(StaticCatalog):
     def to_standardized_catalog(self, df):
 
         def _parse_dist_flag_col(row):
-            if row.dist_flag == 0:
-                return np.nan
-            elif row.dist_flag == 1:
+            if row.dist_flag <= 1:
                 return "phot"
             return "spec"
         

--- a/candidate_vetting/public_catalogs/static_catalogs.py
+++ b/candidate_vetting/public_catalogs/static_catalogs.py
@@ -346,18 +346,6 @@ class Milliquas(StaticCatalog):
         
         # then, of course, init the super class
         super().__init__()
-        
-    def to_standardized_catalog(self, df):
-        df = self._standardize_df(df)
-        df["z_neg_err"] = df.z_err
-        df["z_pos_err"] = df.z_err
-        df["lumdist"] = cosmo.luminosity_distance(df.z).to(u.Mpc).value
-        df["lumdist_err"] = cosmo.luminosity_distance(df.z_err).to(u.Mpc).value
-        df["lumdist_neg_err"] = df.lumdist_err
-        df["lumdist_pos_err"] = df.lumdist_err
-        df["z_type"] = "photo-z"
-        return df
-
 
 class Ps1(StaticCatalog):
     catalog_model = Ps1Q3C

--- a/candidate_vetting/public_catalogs/static_catalogs.py
+++ b/candidate_vetting/public_catalogs/static_catalogs.py
@@ -66,8 +66,8 @@ class DesiDr1(StaticCatalog):
             "default_mag":"default_mag"
         }
     
-    # then, of course, init the super class
-    super().__init__()
+        # then, of course, init the super class
+        super().__init__()
 
     def to_standardized_catalog(self, df):
         df = self._standardize_df(df)

--- a/candidate_vetting/public_catalogs/util.py
+++ b/candidate_vetting/public_catalogs/util.py
@@ -2,6 +2,9 @@
 Some useful variables that will be used throughout this entire directory
 """
 import numpy as np
+
+import warnings
+
 from django.db.models import (
     Func, BooleanField, FloatField, DecimalField, ExpressionWrapper
 )
@@ -33,6 +36,16 @@ def create_phot(target, time, fluxdict, source):
 
     Returns True if it was created, false if it already existed
     """
+    if not fluxdict:
+        warnings.warn("fluxdict is empty")
+    elif "magnitude" in fluxdict.keys() and not("error" in fluxdict.keys()):
+        warnings.warn("Data point contains a magnitude but not an associated "+
+                      "error")
+    elif not(("magnitude" in fluxdict.keys() and "error" in fluxdict.keys()) ^ 
+            ("limit" in fluxdict.keys())):
+        raise ValueError("Must pass EITHER a magnitude and associated error "+
+                         "OR a limit, but not both")
+    
     _, created = ReducedDatum.objects.get_or_create(
         timestamp = time,
         value = fluxdict,

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -173,6 +173,7 @@ def _save_host_galaxy_df(df, target):
         "lumdist_err":"DistErr",
         "z":"z",
         "z_err":"zErr",
+        "z_type":"z_type",
         "default_mag":"Mags",
         "catalog":"Source"
     }
@@ -185,6 +186,7 @@ def _save_host_galaxy_df(df, target):
             "dec",
             "lumdist",
             "z",
+            "z_type",
             "default_mag",
             "catalog"
         ]

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -59,7 +59,7 @@ from candidate_vetting.public_catalogs.static_catalogs import (
 
 # After we order the dataframe by the Pcc score, remove any host matches with a greater
 # Pcc score than this
-PCC_THRESHOLD = 0.1
+PCC_THRESHOLD = 0.15 # this is the value used in Rastinejad+2022
 
 # upper / lower bounds on distance for computing normal / asymmetric Gaussian
 # distributions
@@ -380,11 +380,6 @@ def host_association(target_id:int, radius=50, pcc_threshold=PCC_THRESHOLD):
     # TODO: We will need to put some deduplication code for the galaxy dataframe
     #       here at some point. For now it seems to work without it though!
 
-    # filter out anything above PCC_THRESHOLD
-    # Or, alternatively, only keep the best matching galaxy (if all of the galaxies
-    # have a Pcc greater than PCC_THRESHOLD)
-    pcc_threshold = max(pcc_threshold, df.pcc.min())
-    
     # Finally, filter out anything <= pcc_threshold and sort inversely by pcc
     ret_df = df[df.pcc <= pcc_threshold].sort_values("pcc", ascending=True)
     
@@ -393,8 +388,11 @@ def host_association(target_id:int, radius=50, pcc_threshold=PCC_THRESHOLD):
     print(f"Queries finished in {end-start}s")
 
     # save the host galaxy dataframe to the TargetExtra "Host Galaxies" keyword
+    if not len(ret_df):
+        # then we don't need to actually save any host information
+        return ret_df
+
     _save_host_galaxy_df(ret_df, target)
-    
     return ret_df
 
 def host_distance_match(

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -415,7 +415,6 @@ def host_association(target_id:int, radius=50, pcc_threshold=PCC_THRESHOLD):
     if not len(ret_df):
         # then we don't need to actually save any host information
         return ret_df
-
     _save_host_galaxy_df(ret_df, target)
     return ret_df
 

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -507,7 +507,7 @@ def get_distance_score(host_df, target_id, nonlocalized_event_name):
     """
     # first check if this target has a measured redshift
     targ = Target.objects.get(id=target_id)
-    if not np.isnan(targ.redshift):
+    if targ.redshift is not None and not np.isnan(targ.redshift):
         _lumdist = np.linspace(D_LIM_LOWER, D_LIM_UPPER, int(10*D_LIM_UPPER))
         nle_pdf = _get_nle_distance_pdf(_lumdist,  nonlocalized_event_name, target_id)
         targ_dist = cosmo.luminosity_distance(targ.redshift).to(u.Mpc).value
@@ -535,7 +535,7 @@ def get_eventcandidate_default_distance(target_id:int, nonlocalized_event_name:s
 
     # first check if this target has a redshift associated with it
     targ = Target.objects.get(id = target_id)
-    if not np.isnan(targ.redshift):
+    if targ.redshift is not None and not np.isnan(targ.redshift):
         targ_dist = cosmo.luminosity_distance(targ.redshift).to(u.Mpc).value
         targ_dist_err = cosmo.luminosity_distance(1e-3).to(u.Mpc).value
         return targ_dist, targ_dist_err

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -697,7 +697,7 @@ def agn_distance_match(
         agn_df["dist_norm_joint_prob"] = []
         return agn_df # continue to return an empty dataframe here, but with the correct columns
         
-    # now crossmatch this distance to the host galaxy dataframe
+    # now crossmatch this distance to the to the AGNs dataframe
     _lumdist = np.linspace(D_LIM_LOWER, D_LIM_UPPER, int(10*D_LIM_UPPER))
 
     test_pdf = _get_nle_distance_pdf(

--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -17,6 +17,8 @@ from .vet import (
     associate_agn_2d,
     agn_distance_match,
     update_score_factor,
+    delete_score_factor,
+    get_distance_score
 )
 from .vet_phot import (
     _get_post_disc_phot,
@@ -129,13 +131,16 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
         )
 
         # choose the maximum score out of the top 10 best hosts
-        host_score = host_df.dist_norm_joint_prob.max()
+        host_score = get_distance_score(host_df, target_id, nonlocalized_event_name)
         update_score_factor(event_candidate, "host_distance_score", host_score)
 
     else:
         # if no hosts are found we don't want to bias the final score if the host
         # is just too far
         host_score = 1
+        
+        # and we should also clear out any existing scores for it
+        delete_score_factor(event_candidate, "host_distance_score")
         
     ## photometry scoring
     allphot = _get_post_disc_phot(target_id=target_id, nonlocalized_event=nonlocalized_event)
@@ -148,10 +153,18 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
     )
     if lum is not None:
         update_score_factor(event_candidate, "phot_peak_lum", lum.value)
+    else:
+        delete_score_factor(event_candidate, "phot_peak_lum")
+    
     if max_time is not None:
         update_score_factor(event_candidate, "phot_peak_time", max_time)
+    else:
+        delete_score_factor(event_candidate, "phot_peak_time")
+    
     if decay_rate is not None:
         update_score_factor(event_candidate, "phot_decay_rate", decay_rate)
+    else:
+        delete_score_factor(event_candidate, "phot_decay_rate")
 
     # check for *reliable* predetections before time t_pre
     prephot = _get_pre_disc_phot(target.id,
@@ -171,3 +184,5 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
         if any(v >= PARAM_RANGES["max_predets"] for v in n_predets):
             predet_score = PHOT_SCORE_MIN
             update_score_factor(event_candidate, "predetection_score", predet_score)
+        else:
+            delete_score_factor(event_candidate, "predetection_score")

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -19,7 +19,8 @@ from trove_targets.models import Target
 from candidate_vetting.public_catalogs.phot_catalogs import TNS_Phot
 from candidate_vetting.tasks import async_atlas_query
 
-from .vet import _distance_at_healpix
+from .vet import (get_eventcandidate_default_distance, 
+                  _distance_at_healpix)
 
 
 FILTER_PRIORITY_ORDER = ["r", "g", "V", "R", "G"]
@@ -473,7 +474,10 @@ def _score_phot(allphot, target, nonlocalized_event,
     
     # if we've made it to this point we have at least one detection so
     # we can calculate the luminosity
-    dist, dist_err = _distance_at_healpix(nonlocalized_event.event_id, target.id)
+    dist, _ = get_eventcandidate_default_distance(
+        target.id,
+        nonlocalized_event.event_id
+    )
     lum = compute_peak_lum(phot.mag, phot.magerr, phot["filter"].tolist(), dist*u.Mpc)
 
     phot_score = 1

--- a/candidate_vetting/vet_super_kn.py
+++ b/candidate_vetting/vet_super_kn.py
@@ -17,6 +17,8 @@ from .vet import (
     associate_agn_2d,
     agn_distance_match,
     update_score_factor,
+    delete_score_factor,
+    get_distance_score
 )
 from .vet_phot import (
     _get_post_disc_phot,
@@ -129,13 +131,16 @@ def vet_super_kn(target_id:int, nonlocalized_event_name:Optional[str]=None):
         )
 
         # choose the maximum score out of the top 10 best hosts
-        host_score = host_df.dist_norm_joint_prob.max()
+        host_score = get_distance_score(host_df, target_id, nonlocalized_event_name)
         update_score_factor(event_candidate, "host_distance_score", host_score)
 
     else:
         # if no hosts are found we don't want to bias the final score if the host
         # is just too far
         host_score = 1
+        
+        # and we should also clear out any existing scores for it
+        delete_score_factor(event_candidate, "host_distance_score")
         
     ## photometry scoring
     allphot = _get_post_disc_phot(target_id=target_id, nonlocalized_event=nonlocalized_event)
@@ -148,11 +153,19 @@ def vet_super_kn(target_id:int, nonlocalized_event_name:Optional[str]=None):
     )
     if lum is not None:
         update_score_factor(event_candidate, "phot_peak_lum", lum.value)
+    else:
+        delete_score_factor(event_candidate, "phot_peak_lum")
+
     if max_time is not None:
         update_score_factor(event_candidate, "phot_peak_time", max_time)
+    else:
+        delete_score_factor(event_candidate, "phot_peak_time")
+
     if decay_rate is not None:
         update_score_factor(event_candidate, "phot_decay_rate", decay_rate)
-
+    else:
+        delete_score_factor(event_candidate, "phot_decay_rate")
+    
     # check for *reliable* predetections before time t_pre
     prephot = _get_pre_disc_phot(target.id,
                                  nonlocalized_event, 
@@ -171,3 +184,5 @@ def vet_super_kn(target_id:int, nonlocalized_event_name:Optional[str]=None):
         if any(v >= PARAM_RANGES["max_predets"] for v in n_predets):
             predet_score = PHOT_SCORE_MIN
             update_score_factor(event_candidate, "predetection_score", predet_score)
+        else:
+            delete_score_factor(event_candidate, "predetection_score")

--- a/templates/tom_targets/partials/galaxy_table.html
+++ b/templates/tom_targets/partials/galaxy_table.html
@@ -8,7 +8,7 @@
       <th scope="col">Off.  <br/> (")</th>
       <th scope="col">Dist. <br/> (Mpc)</th>
       <th scope="col">Redshift</th>
-      <th scope="col">Redshift Type</th>
+      <th scope="col">Distance Type</th>
       <th scope="col">Mag.  <br/> (AB)</th>
       <th scope="col">Source</th>
     </tr>
@@ -53,6 +53,6 @@
       <td>{{ galaxy.Source }}</td>
     </tr>
   {% empty %}
-    <tr><td colspan=9>No host galaxies stored</td></tr>
+    <tr><td colspan=9>No viable host galaxies stored</td></tr>
   {% endfor %}
 </table>

--- a/templates/tom_targets/partials/galaxy_table.html
+++ b/templates/tom_targets/partials/galaxy_table.html
@@ -8,6 +8,7 @@
       <th scope="col">Off.  <br/> (")</th>
       <th scope="col">Dist. <br/> (Mpc)</th>
       <th scope="col">Redshift</th>
+      <th scope="col">Redshift Type</th>
       <th scope="col">Mag.  <br/> (AB)</th>
       <th scope="col">Source</th>
     </tr>
@@ -35,14 +36,17 @@
       {% if galaxy.z and galaxy.z|floatformat != 'nan'%}
         {% if galaxy.zErr|islist %}
           <td> {{ galaxy.z|floatformat:2 }}<span class="supsubz"><sup>+{{ galaxy.zErr.1|floatformat:2 }}</sup><sub>-{{ galaxy.zErr.0|floatformat:2 }}</sub></span> </td>
+          <td> {{ galaxy.z_type }} </td>
 	{% else %}
 	  {% if galaxy.zErr|floatformat == 'nan' %}
 	    <td> {{ galaxy.z|floatformat:2 }} (no err.) </td>
 	  {% else %}
             <td> {{ galaxy.z|floatformat:2 }}&nbsp;&plusmn;&nbsp;{{ galaxy.zErr|floatformat:2 }} </td>
 	  {% endif %}
+	  <td> {{ galaxy.z_type }} </td>
 	{% endif %}
       {% else %}
+        <td> </td>
         <td> </td>
       {% endif %}
       <td><i>{{ galaxy.Filter }}</i>&nbsp;=&nbsp;{{ galaxy.Mags|floatformat:1 }}</td>


### PR DESCRIPTION
This PR introduces the changes made in PR #66 into the `ssm` branch. The changes are identical, with the exceptions of some code being found in `vet_phot` or `vet` rather than `vet_bns` and corresponding scripts for KN-in-SN and super-KN. 