### PR TITLE
Fix target redshift none bug

### DIFF
--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -431,7 +431,7 @@ def get_distance_score(host_df, target_id, nonlocalized_event_name):
     """
     # first check if this target has a measured redshift
     targ = Target.objects.get(id=target_id)
-    if not np.isnan(targ.redshift):
+    if targ.redshift and not np.isnan(targ.redshift):
         _lumdist = np.linspace(D_LIM_LOWER, D_LIM_UPPER, int(10*D_LIM_UPPER))
         nle_pdf = _get_nle_distance_pdf(_lumdist,  nonlocalized_event_name, target_id)
         targ_dist = cosmo.luminosity_distance(targ.redshift).to(u.Mpc).value

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -431,7 +431,7 @@ def get_distance_score(host_df, target_id, nonlocalized_event_name):
     """
     # first check if this target has a measured redshift
     targ = Target.objects.get(id=target_id)
-    if targ.redshift and not np.isnan(targ.redshift):
+    if targ.redshift is not None and not np.isnan(targ.redshift):
         _lumdist = np.linspace(D_LIM_LOWER, D_LIM_UPPER, int(10*D_LIM_UPPER))
         nle_pdf = _get_nle_distance_pdf(_lumdist,  nonlocalized_event_name, target_id)
         targ_dist = cosmo.luminosity_distance(targ.redshift).to(u.Mpc).value

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -459,7 +459,7 @@ def get_eventcandidate_default_distance(target_id:int, nonlocalized_event_name:s
 
     # first check if this target has a redshift associated with it
     targ = Target.objects.get(id = target_id)
-    if not np.isnan(targ.redshift):
+    if targ.redshift is not None and not np.isnan(targ.redshift):
         targ_dist = cosmo.luminosity_distance(targ.redshift).to(u.Mpc).value
         targ_dist_err = cosmo.luminosity_distance(1e-3).to(u.Mpc).value
         return targ_dist, targ_dist_err


### PR DESCRIPTION
Catch the case where the target redshift is not nan but rather None. This is how we have it in the `ssm` branch; I suspect we just got some wires crossed in the frenzy to push things before the holidays!