### PR TITLE
Kwargs for parameter ranges in vetting functions, t_pre in _get_post_disc_phot

### DIFF
--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -50,7 +50,8 @@ PARAM_RANGES = dict(
 )
 
 
-def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
+def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None,
+            param_ranges:dict=PARAM_RANGES):
 
     # get the correct EventCandidate object for this target_id and nonlocalized event
     nonlocalized_event = NonLocalizedEvent.objects.get(
@@ -146,12 +147,12 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
     ## photometry scoring
     allphot = _get_post_disc_phot(target_id=target_id, 
                                   nonlocalized_event=nonlocalized_event,
-                                  t_post=PARAM_RANGES["t_post"])
+                                  t_post=param_ranges["t_post"])
     phot_score, lum, max_time, decay_rate, _, _ = _score_phot(
         allphot=allphot,
         target = target,
         nonlocalized_event = nonlocalized_event,
-        param_ranges=PARAM_RANGES,
+        param_ranges=param_ranges,
         filt = ["g", "r", "i", "o", "c"] # use the common optical filters
     )
     if lum is not None:
@@ -172,7 +173,7 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
     # check for *reliable* predetections before time t_pre
     prephot = _get_pre_disc_phot(target_id=target.id,
                                  nonlocalized_event=nonlocalized_event, 
-                                 t_pre=PARAM_RANGES["t_pre"])
+                                 t_pre=param_ranges["t_pre"])
     predet_score = 1
     if prephot is not None and len(prephot):
         try:
@@ -184,7 +185,7 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
             )
         except ValueError:
             n_predets = [0] # this ValueError only happens when there aren't any predets
-        if any(v >= PARAM_RANGES["max_predets"] for v in n_predets):
+        if any(v >= param_ranges["max_predets"] for v in n_predets):
             predet_score = PHOT_SCORE_MIN
             update_score_factor(event_candidate, "predetection_score", predet_score)
         else:

--- a/candidate_vetting/vet_kn_in_sn.py
+++ b/candidate_vetting/vet_kn_in_sn.py
@@ -50,7 +50,8 @@ PARAM_RANGES = dict(
 )
 
 
-def vet_kn_in_sn(target_id:int, nonlocalized_event_name:Optional[str]=None):
+def vet_kn_in_sn(target_id:int, nonlocalized_event_name:Optional[str]=None,
+                 param_ranges:dict=PARAM_RANGES):
 
     # get the correct EventCandidate object for this target_id and nonlocalized event
     nonlocalized_event = NonLocalizedEvent.objects.get(
@@ -146,12 +147,12 @@ def vet_kn_in_sn(target_id:int, nonlocalized_event_name:Optional[str]=None):
     ## photometry scoring
     allphot = _get_post_disc_phot(target_id=target_id, 
                                   nonlocalized_event=nonlocalized_event,
-                                  t_post=PARAM_RANGES["t_post"])
+                                  t_post=param_ranges["t_post"])
     phot_score, lum, max_time, decay_rate, _, _ = _score_phot(
         allphot=allphot,
         target = target,
         nonlocalized_event = nonlocalized_event,
-        param_ranges=PARAM_RANGES,
+        param_ranges=param_ranges,
         filt = ["g", "r", "i", "o", "c"] # use the common optical filters
     )
     if lum is not None:
@@ -172,7 +173,7 @@ def vet_kn_in_sn(target_id:int, nonlocalized_event_name:Optional[str]=None):
     # check for *reliable* predetections before time t_pre
     prephot = _get_pre_disc_phot(target_id=target.id,
                                  nonlocalized_event=nonlocalized_event, 
-                                 t_pre=PARAM_RANGES["t_pre"])
+                                 t_pre=param_ranges["t_pre"])
     predet_score = 1
     if prephot is not None and len(prephot):
         try:
@@ -184,7 +185,7 @@ def vet_kn_in_sn(target_id:int, nonlocalized_event_name:Optional[str]=None):
             )
         except ValueError:
             n_predets = [0] # this ValueError only happens when there aren't any predets
-        if any(v >= PARAM_RANGES["max_predets"] for v in n_predets):
+        if any(v >= param_ranges["max_predets"] for v in n_predets):
             predet_score = PHOT_SCORE_MIN
             update_score_factor(event_candidate, "predetection_score", predet_score)
         else:

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -126,12 +126,13 @@ def _get_phot(target_id:int, nonlocalized_event:NonLocalizedEvent) -> pd.DataFra
 def _get_post_disc_phot(
         target_id:int,
         nonlocalized_event:NonLocalizedEvent,
-        t_post:float=np.inf
+        t_post:float=np.inf,
+        t_pre:float=0
 ) -> pd.DataFrame:
     photdf = _get_phot(target_id, nonlocalized_event)
     if not len(photdf):
         return 
-    phot_post_disc = photdf.loc[(t_post >= photdf.dt) & (photdf.dt >= 0)]
+    phot_post_disc = photdf.loc[(t_post >= photdf.dt) & (photdf.dt >= t_pre)]
     return phot_post_disc
     
 def _get_pre_disc_phot(

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -131,7 +131,7 @@ def _get_post_disc_phot(
     photdf = _get_phot(target_id, nonlocalized_event)
     if not len(photdf):
         return 
-    phot_post_disc = photdf[t_post >= photdf.dt >= 0]
+    phot_post_disc = photdf.loc[(t_post >= photdf.dt) & (photdf.dt >= 0)]
     return phot_post_disc
     
 def _get_pre_disc_phot(

--- a/candidate_vetting/vet_super_kn.py
+++ b/candidate_vetting/vet_super_kn.py
@@ -50,7 +50,8 @@ PARAM_RANGES = dict(
 )
 
 
-def vet_super_kn(target_id:int, nonlocalized_event_name:Optional[str]=None):
+def vet_super_kn(target_id:int, nonlocalized_event_name:Optional[str]=None,
+                 param_ranges:dict=PARAM_RANGES):
 
     # get the correct EventCandidate object for this target_id and nonlocalized event
     nonlocalized_event = NonLocalizedEvent.objects.get(
@@ -146,12 +147,12 @@ def vet_super_kn(target_id:int, nonlocalized_event_name:Optional[str]=None):
     ## photometry scoring
     allphot = _get_post_disc_phot(target_id=target_id, 
                                   nonlocalized_event=nonlocalized_event,
-                                  t_post=PARAM_RANGES["t_post"])
+                                  t_post=param_ranges["t_post"])
     phot_score, lum, max_time, decay_rate, _, _ = _score_phot(
         allphot=allphot,
         target = target,
         nonlocalized_event = nonlocalized_event,
-        param_ranges=PARAM_RANGES,
+        param_ranges=param_ranges,
         filt = ["g", "r", "i", "o", "c"] # use the common optical filters
     )
     if lum is not None:
@@ -172,7 +173,7 @@ def vet_super_kn(target_id:int, nonlocalized_event_name:Optional[str]=None):
     # check for *reliable* predetections before time t_pre
     prephot = _get_pre_disc_phot(target_id=target.id,
                                  nonlocalized_event=nonlocalized_event, 
-                                 t_pre=PARAM_RANGES["t_pre"])
+                                 t_pre=param_ranges["t_pre"])
     predet_score = 1
     if prephot is not None and len(prephot):
         try:
@@ -184,7 +185,7 @@ def vet_super_kn(target_id:int, nonlocalized_event_name:Optional[str]=None):
             )
         except ValueError:
             n_predets = [0] # this ValueError only happens when there aren't any predets
-        if any(v >= PARAM_RANGES["max_predets"] for v in n_predets):
+        if any(v >= param_ranges["max_predets"] for v in n_predets):
             predet_score = PHOT_SCORE_MIN
             update_score_factor(event_candidate, "predetection_score", predet_score)
         else:

--- a/custom_code/templatetags/event_candidate_extras.py
+++ b/custom_code/templatetags/event_candidate_extras.py
@@ -32,10 +32,11 @@ DICT_TRANSIENTS_PARAM_RANGES = {
 
 
 # default subscore names 
-SUBSCORE_NAMES = ['host_distance_score',
-                  'predetection_score',
+SUBSCORE_NAMES = ['skymap_score',
+                  'host_distance_score',
                   'ps_score',
-                  'skymap_score',
+                  'agn_score',
+                  'predetection_score',
                   'phot_peak_lum',
                   'phot_peak_time',
                   'phot_decay_rate']

--- a/custom_code/templatetags/event_candidate_extras.py
+++ b/custom_code/templatetags/event_candidate_extras.py
@@ -30,12 +30,22 @@ DICT_TRANSIENTS_PARAM_RANGES = {
     "KN-in-SN":KN_IN_SN_PARAM_RANGES,
     "super-KN":SUPER_KN_PARAM_RANGES}
 
+
+# default subscore names 
+SUBSCORE_NAMES = ['host_distance_score',
+                  'predetection_score',
+                  'ps_score',
+                  'skymap_score',
+                  'phot_peak_lum',
+                  'phot_peak_time',
+                  'phot_decay_rate']
+
 register = template.Library()
 
 @register.simple_tag
 def get_event_candidate_scores(event_candidates, 
                                dict_transients_param_ranges=DICT_TRANSIENTS_PARAM_RANGES,
-                               *subscore_names):
+                               subscore_names=SUBSCORE_NAMES):
     """Get the event candidate scores for everything in subscore_names
 
     event_candidates should be a django queryset of EventCandidate objects

--- a/custom_code/templatetags/event_candidate_extras.py
+++ b/custom_code/templatetags/event_candidate_extras.py
@@ -33,7 +33,9 @@ DICT_TRANSIENTS_PARAM_RANGES = {
 register = template.Library()
 
 @register.simple_tag
-def get_event_candidate_scores(event_candidates, *subscore_names):
+def get_event_candidate_scores(event_candidates, 
+                               dict_transients_param_ranges=DICT_TRANSIENTS_PARAM_RANGES,
+                               *subscore_names):
     """Get the event candidate scores for everything in subscore_names
 
     event_candidates should be a django queryset of EventCandidate objects
@@ -54,7 +56,7 @@ def get_event_candidate_scores(event_candidates, *subscore_names):
         }
         for transient in TRANSIENTS: 
             # allowed parameter ranges for given transient
-            param_ranges = DICT_TRANSIENTS_PARAM_RANGES[transient]
+            param_ranges = dict_transients_param_ranges[transient]
             
             phot_score = 1 # reset to 1.0 for each transient
             

--- a/trove_nonlocalizedevents/templates/trove_nonlocalizedevents/candidate_list.html
+++ b/trove_nonlocalizedevents/templates/trove_nonlocalizedevents/candidate_list.html
@@ -22,7 +22,7 @@
         </tr>
       </thead>
       <tbody>
-	{% get_event_candidate_scores object_list 'host_distance_score' 'predetection_score' 'ps_score' 'skymap_score' 'phot_peak_lum' 'phot_peak_time' 'phot_decay_rate' as candidates_to_display %}
+	{% get_event_candidate_scores object_list as candidates_to_display %}
 	{% for candidate in candidates_to_display %}
         <tr>
 	  <td>{{forloop.counter}}</td>


### PR DESCRIPTION
This PR makes a few changes:
- Make parameter ranges (mostly relevant for photometry scoring) a keyword argument in `candidate_vetting.vet_x.vet_x` (where x=`bns`, 'kn_in_sn`, and `super_kn`), rather than looking for a constant defined in the module. if not specified by user, defaults to the constant in the module
- Make a dictionary of the form `{"transient":{"parameter":[a,b]}}` a keyword argument for `custom_code.templatetags.event_candidate_extras()`. If not specified by user, defaults to the constant in the module, which itself relies on importing defaults from the `vet_x` modules
- Make `subscore_names` into a keyword argument with a default setting for `custom_code.templatetags.event_candidate_extras()` as well
- Update trove NLE candidate list template to work with new `event_candidate_extras`
- Fixes a bug related to inequality with `t_post` in `vet_phot._get_post_disc_phot()` (already fixed on integation branch, see PR #76 )
