### PR TITLE
Improved vetting utility

### DIFF
--- a/candidate_vetting/apps.py
+++ b/candidate_vetting/apps.py
@@ -5,7 +5,7 @@ class CustomCodeConfig(AppConfig):
     name = 'candidate_vetting'
     def target_detail_buttons(self):
         return {
-            'namespace': 'candidate_vetting:vet',
+            'namespace': 'candidate_vetting:vet_form',
             'title': 'Run kilonova candidate vetting',
             'class': "btn btn-pink",
             'text': 'Vet'

--- a/candidate_vetting/config.py
+++ b/candidate_vetting/config.py
@@ -1,0 +1,23 @@
+"""
+Some config variables for vetting that are used in multiple places
+"""
+from .vet_basic import vet_basic
+from .vet_bns import vet_bns
+#from .vet_kn_in_sn import vet_kn_in_sn
+#from .vet_super_kn import vet_super_kn
+
+VETTING_FORM_CHOICES = [ # these tuples are (value to save, value to show)
+    ("KN", "Classical Kilonova"),
+#    ("KNinSN", "Kilonova in Supernova"),
+#    ("superKN", "Super-Kilonova"),
+#    ("agn", "BBH and/or AGN Flare"),
+    ("basic", "Basic Vetting")
+]
+
+FORM_CHOICE_FUNC_MAP = { # this should have the same keys as the VETTING_FORM_CHOICES variable!
+    "KN":vet_bns,
+#    "KNinSN":vet_kn_in_sn,
+#    "superKN":vet_super_kn,
+#    "agn":???,
+    "basic":vet_basic
+}

--- a/candidate_vetting/forms.py
+++ b/candidate_vetting/forms.py
@@ -6,7 +6,7 @@ from django.forms import (
 from .config import VETTING_FORM_CHOICES
 
 class VettingChoiceForm(Form):
-    picked = ChoiceField(
+    vetting_method = ChoiceField(
         choices = VETTING_FORM_CHOICES,
         widget = RadioSelect()
     )

--- a/candidate_vetting/forms.py
+++ b/candidate_vetting/forms.py
@@ -1,0 +1,18 @@
+from django.forms import (
+    Form,
+    ChoiceField,
+    RadioSelect
+)
+
+class VettingChoiceForm(Form):
+    choices = [ # these tuples are (value to save, value to show)
+        ("KN", "Classical Kilonova"),
+        ("KN-in-SN", "Kilonova in Supernova"),
+        ("superKN", "Super-Kilonova"),
+        ("agn", "BBH and/or AGN Flare"),
+        ("basic", "Basic Vetting")
+    ]
+    picked = ChoiceField(
+        choices = choices,
+        widget = RadioSelect()
+    )

--- a/candidate_vetting/forms.py
+++ b/candidate_vetting/forms.py
@@ -3,16 +3,10 @@ from django.forms import (
     ChoiceField,
     RadioSelect
 )
+from .config import VETTING_FORM_CHOICES
 
 class VettingChoiceForm(Form):
-    choices = [ # these tuples are (value to save, value to show)
-        ("KN", "Classical Kilonova"),
-        ("KN-in-SN", "Kilonova in Supernova"),
-        ("superKN", "Super-Kilonova"),
-        ("agn", "BBH and/or AGN Flare"),
-        ("basic", "Basic Vetting")
-    ]
     picked = ChoiceField(
-        choices = choices,
+        choices = VETTING_FORM_CHOICES,
         widget = RadioSelect()
     )

--- a/candidate_vetting/templates/candidate_vetting/vetting_form.html
+++ b/candidate_vetting/templates/candidate_vetting/vetting_form.html
@@ -1,0 +1,7 @@
+<form action="" method="post">
+    {% csrf_token %}
+    {{ form }}
+    <button type="submit" class="btn btn-primary">
+      Vet
+    </button>
+</form>

--- a/candidate_vetting/templates/candidate_vetting/vetting_form.html
+++ b/candidate_vetting/templates/candidate_vetting/vetting_form.html
@@ -1,7 +1,124 @@
-<form action="" method="post">
-    {% csrf_token %}
-    {{ form }}
-    <button type="submit" class="btn btn-primary">
-      Vet
-    </button>
-</form>
+{% extends 'tom_targets/partials/base.html' %}
+{% load crispy_forms_tags comments bootstrap4 %}
+
+{% block content %}
+<style>
+    /* 1. Background styling - Using your blurred image logic from before */
+    body {
+        background-color: white; 
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0;
+        font-family: sans-serif;
+    }
+
+    /* 2. The Card: High contrast Dark Mode */
+    .vetting-card {
+        /* Deep dark background so white text stands out perfectly */
+        background: rgba(20, 20, 25, 0.95); 
+        backdrop-filter: blur(20px);
+        -webkit-backdrop-filter: blur(20px);
+        
+        /* Thin, bright border to define the card against the black BG */
+        border: 1px solid rgba(255, 255, 255, 0.2); 
+        border-radius: 12px;
+        padding: 40px;
+        width: 100%;
+        max-width: 450px;
+        box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+        color: #FFFFFF; /* Pure white text for headers */
+    }
+
+    .vetting-card h2 {
+        font-weight: 700;
+        margin-bottom: 25px;
+        text-align: center;
+        color: #fff;
+    }
+
+    /* 3. Form Labels: High contrast light gray/white */
+    .vetting-card label {
+        color: #e0e0e0 !important; 
+        font-weight: 600;
+        font-size: 0.95rem;
+        margin-bottom: 8px;
+        display: block;
+    }
+
+    /* 4. Inputs: Pure black background with white text and bright borders */
+    .vetting-card input, 
+    .vetting-card select, 
+    .vetting-card textarea {
+        background: #000 !important; 
+        border: 2px solid #444 !important; /* Thicker, darker border */
+        color: #fff !important; 
+        border-radius: 8px !important;
+        padding: 10px !important;
+        width: 100%;
+    }
+
+    /* Highlight inputs when clicked */
+    .vetting-card input:focus, 
+    .vetting-card select:focus {
+        border-color: #e91e63 !important; /* Pink glow on focus */
+        outline: none;
+    }
+
+    /* 5. The "Submit" Button: Vivid Pink */
+    .btn-vet {
+        background: pink !important; 
+        color: black !important;
+        border: none;
+        padding: 14px;
+        border-radius: 8px;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        transition: all 0.2s ease-in-out;
+        margin-top: 20px;
+        width: 100%;
+    }
+
+    .btn-vet:hover {
+        background: #ff4081 !important;
+        transform: scale(1.02);
+        box-shadow: 0 0 20px rgba(233, 30, 99, 0.5);
+    }
+
+    /* Cancel Link */
+    .cancel-link {
+        display: block;
+        text-align: center;
+        margin-top: 20px;
+        color: #aaa;
+        text-decoration: none;
+        font-size: 0.85rem;
+    }
+    .cancel-link:hover {
+        color: #fff;
+    }
+</style>
+
+<div class="container d-flex justify-content-center">
+    <div class="vetting-card">
+        <h2>Target Vetting Submission Page</h2>
+        
+        <form action="" method="post">
+            {% csrf_token %}
+          
+            {{ form|crispy }}
+            
+            <div class="d-grid">
+                <button type="submit" class="btn btn-primary btn-vet">
+                    Execute Vetting Sequence
+                </button>
+                <a href="{{ request.META.HTTP_REFERER }}" class="text-center mt-3 text-white-50 text-decoration-none small">
+                    Cancel and Return
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/candidate_vetting/urls.py
+++ b/candidate_vetting/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import TargetVettingView
+from .views import TargetVettingView, TargetVettingFormView
 
 from tom_common.api_router import SharedAPIRootRouter
 
@@ -9,5 +9,6 @@ router = SharedAPIRootRouter()
 app_name = 'candidate_vetting'
 
 urlpatterns = [
-    path('targets/<int:pk>/vet/', TargetVettingView.as_view(), name='vet'),
+    path('targets/<int:pk>/vet/<vetting_mode>', TargetVettingView.as_view(), name='vet'),
+    path('targets/<int:pk>/vetchoice/', TargetVettingFormView.as_view(), name='vet_form')
 ]

--- a/candidate_vetting/urls.py
+++ b/candidate_vetting/urls.py
@@ -9,6 +9,6 @@ router = SharedAPIRootRouter()
 app_name = 'candidate_vetting'
 
 urlpatterns = [
-    path('targets/<int:pk>/vet/<vetting_mode>', TargetVettingView.as_view(), name='vet'),
+    path('targets/<int:pk>/vet/<vetting_mode>/', TargetVettingView.as_view(), name='vet'),
     path('targets/<int:pk>/vetchoice/', TargetVettingFormView.as_view(), name='vet_form')
 ]

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -455,7 +455,7 @@ def get_distance_score(host_df, target_id, nonlocalized_event_name):
     """
     # first check if this target has a measured redshift
     targ = Target.objects.get(id=target_id)
-    if not np.isnan(targ.redshift):
+    if targ.redshift is not None and not np.isnan(targ.redshift):
         _lumdist = np.linspace(D_LIM_LOWER, D_LIM_UPPER, int(10*D_LIM_UPPER))
         nle_pdf = _get_nle_distance_pdf(_lumdist,  nonlocalized_event_name, target_id)
         targ_dist = cosmo.luminosity_distance(targ.redshift).to(u.Mpc).value
@@ -483,7 +483,7 @@ def get_eventcandidate_default_distance(target_id:int, nonlocalized_event_name:s
 
     # first check if this target has a redshift associated with it
     targ = Target.objects.get(id = target_id)
-    if not np.isnan(targ.redshift):
+    if targ.redshift is not None and not np.isnan(targ.redshift):
         targ_dist = cosmo.luminosity_distance(targ.redshift).to(u.Mpc).value
         targ_dist_err = cosmo.luminosity_distance(1e-3).to(u.Mpc).value
         return targ_dist, targ_dist_err

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -60,6 +60,22 @@ from candidate_vetting.public_catalogs.static_catalogs import (
     DesiDr1
 )
 
+HOST_DF_COLMAP = {
+    "name":"ID",
+    "pcc":"PCC",
+    "offset":"Offset",
+    "ra":"RA",
+    "dec": "Dec",
+    "lumdist":"Dist",
+    "lumdist_err":"DistErr",
+    "z":"z",
+    "z_err":"zErr",
+    "z_type":"z_type",
+    "default_mag":"Mags",
+    "catalog":"Source"
+}
+HOST_DF_COLMAP_INVERSE = {v:k for k,v in HOST_DF_COLMAP.items()}
+
 # After we order the dataframe by the Pcc score, remove any host matches with a greater
 # Pcc score than this
 PCC_THRESHOLD = 0.15 # this is the value used in Rastinejad+2022
@@ -189,27 +205,35 @@ def delete_score_factor(event_candidate, key):
 
     if matches.count():
         matches.delete()
-    
+
+def save_score_to_targetextra(target, key, score):
+    """
+    Saves the scores that don't change to a TargetExtra object rather than a ScoreFactor
+    This is for:
+    1. point source score
+    2. MPC score
+    Since they are independent of the NLE that we are vetting the target against
+    """
+
+    # first delete the host galaxy key for this target if it already exists
+    te = TargetExtra.objects.filter(target_id=target.id, key=key)
+    if te.exists():
+        te.delete()
+
+    # then save the new score
+    TargetExtra.objects.update_or_create(
+        target=target,
+        key=key,
+        value=score
+    )
+
+        
 def _save_host_galaxy_df(df, target):
 
     # first delete the host galaxy key for this target if it already exists
     if TargetExtra.objects.filter(target_id=target.id, key="Host Galaxies").exists():
         TargetExtra.objects.filter(target_id=target.id, key="Host Galaxies").delete()
     
-    col_map = {
-        "name":"ID",
-        "pcc":"PCC",
-        "offset":"Offset",
-        "ra":"RA",
-        "dec": "Dec",
-        "lumdist":"Dist",
-        "lumdist_err":"DistErr",
-        "z":"z",
-        "z_err":"zErr",
-        "z_type":"z_type",
-        "default_mag":"Mags",
-        "catalog":"Source"
-    }
     newdf = df[
         [
             "name",
@@ -234,7 +258,7 @@ def _save_host_galaxy_df(df, target):
         else neg # errors are not assymetric
         for neg, pos in zip(df.lumdist_neg_err, df.lumdist_pos_err)
     ]
-    newdf = newdf.rename(columns=col_map)
+    newdf = newdf.rename(columns=HOST_DF_COLMAP)
     TargetExtra.objects.update_or_create(
         target=target,
         key="Host Galaxies",

--- a/candidate_vetting/vet_basic.py
+++ b/candidate_vetting/vet_basic.py
@@ -12,6 +12,8 @@ But without any direct scoring!
 This should also be called before any photometry vetting in the NLE-related
 vetting modules. That way we can reduce the code duplication between them!
 """
+
+import logging
 import io
 from astropy.time import Time
 import pandas as pd
@@ -30,13 +32,15 @@ from .vet_phot import find_public_phot
 
 from trove_mpc import Transient
 
+logger = logging.getLogger(__name__)
+
 def vet_basic(
         target_id:int,
         days_ago_max:int=200,
         overwrite:bool=False,
         queue_priority:int=0
 ):
-    print("Running basic vetting")
+    logger.info("Running basic vetting")
     # get the Target object associated with this target_id
     target = Target.objects.get(id=target_id)
 
@@ -51,7 +55,7 @@ def vet_basic(
     te = TargetExtra.objects.filter(target_id=target.id)
     # run the point source checker
     if overwrite or not te.filter(key="ps_score").exists():
-        print("Running Point Source Matching...")
+        logger.info("Running Point Source Matching...")
         ps_score = point_source_association(target_id)
         save_score_to_targetextra(target, "ps_score", ps_score)
         

--- a/candidate_vetting/vet_basic.py
+++ b/candidate_vetting/vet_basic.py
@@ -30,7 +30,12 @@ from .vet_phot import find_public_phot
 
 from trove_mpc import Transient
 
-def vet_basic(target_id:int, days_ago_max:int=200, overwrite:bool=False):
+def vet_basic(
+        target_id:int,
+        days_ago_max:int=200,
+        overwrite:bool=False,
+        queue_priority:int=0
+):
     print("Running basic vetting")
     # get the Target object associated with this target_id
     target = Target.objects.get(id=target_id)
@@ -40,6 +45,7 @@ def vet_basic(target_id:int, days_ago_max:int=200, overwrite:bool=False):
         target=target,
         forced_phot_tol = 0,
         days_ago_max=days_ago_max,
+        queue_priority=queue_priority
     )
 
     te = TargetExtra.objects.filter(target_id=target.id)

--- a/candidate_vetting/vet_basic.py
+++ b/candidate_vetting/vet_basic.py
@@ -1,0 +1,90 @@
+"""
+the vet_basic function is for when there is not a NLE associated with a transient and
+simply does
+0. Checks for new photometry
+1. point source association
+2. MPC crossmatching
+3. AGN crossmatching
+4. Host association
+
+But without any direct scoring!
+
+This should also be called before any photometry vetting in the NLE-related
+vetting modules. That way we can reduce the code duplication between them!
+"""
+import io
+from astropy.time import Time
+import pandas as pd
+
+from trove_targets.models import Target
+from tom_dataproducts.models import ReducedDatum
+from tom_targets.models import TargetExtra
+
+from .vet import (
+    point_source_association,
+    host_association,
+    save_score_to_targetextra,
+    HOST_DF_COLMAP_INVERSE
+)
+from .vet_phot import find_public_phot
+
+from trove_mpc import Transient
+
+def vet_basic(target_id:int, days_ago_max:int=200, overwrite:bool=False):
+    print("Running basic vetting")
+    # get the Target object associated with this target_id
+    target = Target.objects.get(id=target_id)
+
+    # then check for new photometry
+    find_public_phot(
+        target=target,
+        forced_phot_tol = 0,
+        days_ago_max=days_ago_max,
+    )
+
+    te = TargetExtra.objects.filter(target_id=target.id)
+    # run the point source checker
+    if overwrite or not te.filter(key="ps_score").exists():
+        print("Running Point Source Matching...")
+        ps_score = point_source_association(target_id)
+        save_score_to_targetextra(target, "ps_score", ps_score)
+        
+    # run the minor planet checker
+    if overwrite or not te.filter(key="mpc_match_name").exists():
+        phot = ReducedDatum.objects.filter(
+            target_id=target_id,
+            data_type="photometry",
+            value__magnitude__isnull=False
+        )
+        if phot.exists():
+            latest_det = phot.latest()
+            date = Time(latest_det.timestamp).mjd
+            t = Transient(target.ra, target.dec)
+            mpc_match = t.minor_planet_match(date)
+        else:
+            logger.warn("This candidate has no photometry, skipping MPC!")
+            mpc_match = None
+
+        if mpc_match is not None:
+            # update the score factor information
+            save_score_to_targetextra(
+                target, "mpc_match_name", mpc_match.match_name
+            )
+            save_score_to_targetextra(
+                target, "mpc_match_sep", mpc_match.distance
+            )
+            save_score_to_targetextra(
+                target, "mpc_match_date", latest_det.timestamp
+            )
+        else:
+            save_score_to_targetextra(
+                target, "mpc_match_name", None
+            )
+            
+    # do the Pcc analysis and find a host
+    host_df = host_association(
+        target_id,
+        radius = 5*60
+    )
+            
+    return host_df

--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -10,8 +10,6 @@ import numpy as np
 
 from .vet import (
     skymap_association,
-    point_source_association,
-    host_association,
     host_distance_match,
     update_score_factor,
     delete_score_factor,
@@ -19,6 +17,7 @@ from .vet import (
     get_eventcandidate_default_distance,
     _distance_at_healpix
 )
+from .vet_basic import vet_basic
 from .vet_phot import (
     compute_peak_lum,
     estimate_max_find_decay_rate,
@@ -27,7 +26,6 @@ from .vet_phot import (
     _get_pre_disc_phot,
     get_predetection_stats
 )
-from trove_mpc import Transient
 
 from trove_targets.models import Target
 from tom_dataproducts.models import ReducedDatum
@@ -120,6 +118,7 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
         nonlocalizedevent_id = nonlocalized_event.id,
         target_id = target_id
     )
+    target = Target.objects.get(id=target_id)
     
     # check skymap association
     skymap_score = skymap_association(nonlocalized_event_name, target_id)
@@ -127,42 +126,9 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None):
     if skymap_score < 1e-2:
         return 
 
-    # run the point source checker
-    ps_score = point_source_association(target_id)
-    update_score_factor(event_candidate, "ps_score", ps_score)
-    if ps_score == 0:
-        return
+    # compute the basic scores
+    host_df = vet_basic(event_candidate.target.id)
     
-    # run the minor planet checker
-    target = Target.objects.filter(id=target_id)[0]
-    phot = ReducedDatum.objects.filter(
-        target_id=target_id,
-        data_type="photometry",
-        value__magnitude__isnull=False
-    )
-    if phot.exists():
-        latest_det = phot.latest()
-        date = Time(latest_det.timestamp).mjd
-        t = Transient(target.ra, target.dec)
-        mpc_match = t.minor_planet_match(date)
-    else:
-        logger.warn("This candidate has no photometry, skipping MPC!")
-        mpc_match = None
-
-    if mpc_match is not None:
-        # update the score factor information
-        update_score_factor(event_candidate, "mpc_match_name", mpc_match.match_name)
-        update_score_factor(event_candidate, "mpc_match_sep", mpc_match.distance)
-        update_score_factor(event_candidate, "mpc_match_date", latest_det.timestamp)
-        return
-    
-    mpc_score = 1
-    
-    # do the Pcc analysis and find a host
-    host_df = host_association(
-        target_id,
-        radius = 5*60
-    )
     if len(host_df) != 0:
         # then run the distance comparison for each of these hosts
         host_df = host_distance_match(

--- a/candidate_vetting/views.py
+++ b/candidate_vetting/views.py
@@ -14,6 +14,7 @@ from django.shortcuts import redirect
 from trove_targets.models import Target
 from .forms import VettingChoiceForm 
 from candidate_vetting.vet_bns import vet_bns
+from candidate_vetting.vet_basic import vet_basic
 from candidate_vetting.vet_phot import find_public_phot
 
 import requests
@@ -27,20 +28,33 @@ class TargetVettingFormView(FormView):
     # TODO: Only give the user the form if there is a non-localized event associated
     #       with this target. If there isn't, this should just redirect to the basic
     #       target vetting!
+
+    def get(self, request, *args, **kwargs):
+        referer = request.META.get("HTTP_REFERER")
+        if referer:
+            self.request.session['nle_id'] = urlparse(referer).query
+        return super().get(request, *args, **kwargs)
     
     def form_valid(self, form):
         pk = self.kwargs["pk"]
         vetting_mode = form.cleaned_data["picked"]
         
-        # (optional) do something with the form data here
-        # e.g. save choices to session, database, etc.
-        
-        return redirect(
-            "candidate_vetting:vet",
-            pk=pk,
-            vetting_mode=vetting_mode,
+        # generate the base url
+        base_url = reverse(
+            'candidate_vetting:vet',
+            kwargs=dict(
+                pk=pk,
+                vetting_mode=vetting_mode
+            )
         )
-        
+
+        # then also preserve the query parameters
+        query_str = self.request.session.pop('nle_id', '')
+        print("QUERY STRING:", query_str)
+        if query_str:
+            base_url += f"?{query_str}"
+                    
+        return redirect(base_url)
     
 class TargetVettingView(LoginRequiredMixin, RedirectView):
     """
@@ -50,39 +64,23 @@ class TargetVettingView(LoginRequiredMixin, RedirectView):
         """
         Method that handles the GET requests for this view. Calls the kilonova vetting code.
         """        
-        target = Target.objects.get(pk=kwargs['pk'])
+        target_pk = kwargs['pk']
+        target = Target.objects.get(pk=target_pk)
         vetting_mode = kwargs.get("vetting_mode", "basic")
 
-        # TODO: Based off the vetting_mode, set the vetting that is run. For example,
-        #       if the user selects classical KN then we should run vet_bns
-        
         # get the nonlocalized event name from the referer
-        query_params = parse_qs(
-            urlparse(
-                request.META.get("HTTP_REFERER")
-            ).query
-        )
-        nonlocalized_event_name = query_params.get("nonlocalizedevent")
-        if nonlocalized_event_name is not None:
-            # because parse_qs returns lists for each query item
-            nonlocalized_event_name = nonlocalized_event_name[0]
-
-
-        # first check for new photometry
-        messages.info(request, "Checking for new public forced photometry. We will vet without this, please consider running the vetting again in ~3-5 minutes.")
-        find_public_phot(target, queue_priority=0) # set priority=0 so this jumps the queue (clearly a user cares about it)
-
-        # then run the vetting
-        vet_bns(target.id, nonlocalized_event_name)
+        nonlocalized_event_name = request.GET.get("nonlocalizedevent")
         
-        return HttpResponseRedirect(self.get_redirect_url())
-
-    def get_redirect_url(self):
-        """
-        Returns redirect URL as specified in the HTTP_REFERER field of the request.
-
-        :returns: referer
-        :rtype: str
-        """
-        referer = self.request.META.get('HTTP_REFERER', '/')
-        return referer
+        # then run the vetting
+        vetting_func = FORM_CHOICE_FUNC_MAP[vetting_mode]
+        if vetting_mode == "basic" or nonlocalized_event_name is None:
+            vet_basic(target.id)
+        else:
+            vetting_func(target.id, nonlocalized_event_name)
+        
+        return redirect(
+            reverse(
+                "targets:detail",
+                kwargs=dict(pk=target_pk)
+            )
+        ) # this redirects back to the original target page

--- a/candidate_vetting/views.py
+++ b/candidate_vetting/views.py
@@ -37,7 +37,7 @@ class TargetVettingFormView(FormView):
     
     def form_valid(self, form):
         pk = self.kwargs["pk"]
-        vetting_mode = form.cleaned_data["picked"]
+        vetting_mode = form.cleaned_data["vetting_method"]
         
         # generate the base url
         base_url = reverse(

--- a/candidate_vetting/views.py
+++ b/candidate_vetting/views.py
@@ -18,6 +18,8 @@ from candidate_vetting.vet_phot import find_public_phot
 
 import requests
 
+from .config import FORM_CHOICE_FUNC_MAP
+
 class TargetVettingFormView(FormView):
     template_name = "candidate_vetting/vetting_form.html"
     form_class = VettingChoiceForm

--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -112,8 +112,8 @@ def target_post_save(target, created=True, lookback_days_nle=7, lookback_days_ob
                 update_or_create_target_extra(target, 'MW E(B-V)', mwebv)
                 messages.append(f'MW E(B-V) set to {mwebv:.4f}')
 
-        # then query for new photometry
-        find_public_phot(target)
+        # do the "basic" vetting (PS, MPC, Host association)
+        vet_basic(target.id)
         
         # then check if this target is associated with any NLEs
         new_candidates = associate_nle_with_target(

--- a/custom_code/templatetags/event_candidate_extras.py
+++ b/custom_code/templatetags/event_candidate_extras.py
@@ -11,6 +11,7 @@ from django.db.models import FloatField
 from django.db.models.functions import Cast
 from tom_nonlocalizedevents.models import EventCandidate, NonLocalizedEvent
 from trove_targets.models import Target
+from tom_targets.models import TargetExtra
 from candidate_vetting.models import ScoreFactor
 from candidate_vetting.vet_bns import (
     PARAM_RANGES as KN_PARAM_RANGES,
@@ -112,10 +113,26 @@ def display_score_details(target_id):
         return "Target ID is None!"
 
     target = Target.objects.get(id=target_id)
-    
+
+    basic_score_details = []
+    targetextra_keys = [
+        "ps_score",
+        "mpc_match_name",
+        "mpc_match_sep",
+        "mpc_match_date",
+        "mpc_match_date"
+    ]
+    te = TargetExtra.objects.filter(target_id=target_id)
+    for key in targetextra_keys:
+        basic_score_details.append(te.filter(key=key))
+
     score_details = []
     for event_candidate in target.eventcandidate_set.all():
-        score_details.append(event_candidate.scorefactor_set.all())
+        sf_set = event_candidate.scorefactor_set.exclude(
+            key__in=targetextra_keys # we want the value from TargetExtra
+        ).all()
+        print(sf_set)
+        score_details.append(sf_set)
 
     res = {}
     keymap = dict(
@@ -124,8 +141,31 @@ def display_score_details(target_id):
         host_distance_score = ("3D Association Score", _float_format),
         phot_peak_lum = ("Maximum Luminosity", partial(_sci_format, unit="erg/s")),
         phot_peak_time = ("Time of Maximum Light Curve", partial(_float_format, unit="days")),
-        phot_decay_rate = ("Light Curve Slope (positive is brightening)", partial(_float_format, unit="mag/day"))
+        phot_decay_rate = ("Light Curve Slope (positive is brightening)", partial(_float_format, unit="mag/day")),
+        mpc_match_name = ("MPC Match Name", _str_format),
+        mpc_match_date = ("MPC Match Date", _str_format),
+        mpc_match_sep = ('MPC Match Separation (")', _float_format),
     )
+
+    # first the basic score details
+    basic_score_key = "Basic Score Details"
+    for qs in basic_score_details:
+        for te in qs:
+            if basic_score_key not in res:
+                res[basic_score_key] = ""
+            if te.key in keymap:
+                label, fmter = keymap[te.key]
+            else:
+                label = te.key
+                fmter = _float_format
+            if te.value is None or isinstance(te.value, str):
+                s = te.value
+            else:
+                s = fmter(float(te.value))
+            res[basic_score_key] += f"&emsp;{label}: {s}\n" 
+            
+    
+    # then the NLE specific ones
     for queryset in score_details:
         for score_factor in queryset:
             nle = score_factor.event_candidate.nonlocalizedevent
@@ -157,3 +197,6 @@ def _sci_format(flt, unit=""):
 
 def _bool_format(flt):
     return int(flt)
+
+def _str_format(s):
+    return s


### PR DESCRIPTION
This is a major refactor of the backend vetting workflow to 
1. Allow for users to choose which type of vetting to execute
2. Prevent re-running the PS and MPC vetting unless absolutely necessary, since these can take the longest and DO NOT CHANGE between NLEs
3. Allow for users to perform just the "basic vetting" operations for targets that do not have NLEs associated with them. 

This should address Issue #64 and also allow for vetting to occur when a NLE is not associated with a target,