### PR TITLE
Catch scenario where neither power law nor broken power law fits the photometry

### DIFF
--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -93,11 +93,15 @@ def _score_phot(allphot, target, nonlocalized_event, filt=None):
     # at this filter
     if len(phot) > 1: # has to be at least 2 points to fit the powerlaw        
         # find the maximum and decay rate
-        _model,_best_fit_params,max_time,decay_rate = estimate_max_find_decay_rate(
-            phot.dt,
-            phot.mag,
-            phot.magerr
-        )
+        try:
+            _model,_best_fit_params,max_time,decay_rate = estimate_max_find_decay_rate(
+                phot.dt,
+                phot.mag,
+                phot.magerr
+            )
+        except RuntimeError:
+            print("Could not fit a power law or broken power law --> not setting peak_time or decay_rate")
+            return phot_score, lum, None, None, None, None 
         
         # check if these are within the appropriate ranges
         if max_time < PARAM_RANGES["peak_time"][0] or max_time > PARAM_RANGES["peak_time"][1]:

--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -100,7 +100,7 @@ def _score_phot(allphot, target, nonlocalized_event, filt=None):
                 phot.magerr
             )
         except RuntimeError:
-            print("Could not fit a power law or broken power law --> not setting peak_time or decay_rate")
+            logger.warning("Could not fit a power law or broken power law --> not setting peak_time or decay_rate")
             return phot_score, lum, None, None, None, None 
         
         # check if these are within the appropriate ranges

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -249,6 +249,9 @@ def estimate_max_find_decay_rate(
         bpl_model_y = _broken_powerlaw(dt_days, *bpl_popt)
         bpl_ssr = _ssr(bpl_model_y, mag)
         bpl_info_crit = info_crit(bpl_ssr, bpl_nparams, len(mag))
+    else:
+        pl_info_crit = np.inf
+        bpl_info_crit = np.inf
         
     # now we can prefer the model with the lower AIC score
     if (not pl_failed and bpl_failed) or (pl_info_crit < bpl_info_crit and not pl_failed):


### PR DESCRIPTION
I guess this is something we've not encountered before? I encountered it when trying to fit AT2025adjf only considering photometry up to 1.0 days post-S251112cm merger. I've updated the photometry vetting to catch this scenario and just not return the rise time and decay rate.

Defining the AICs for the power law and broken power law as infinity is necessary so we don't get an `UnboundLocalError` on line 254 (now 257) when trying to compare `pl_info_crit` and `bpl_info_crit`.