### PR TITLE
Updates to SSM photometry scoring, 1/?

### DIFF
--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -43,7 +43,8 @@ PARAM_RANGES = dict(
     decay_rate = [-np.inf, -0.1],
     max_predets = 3,
     t_pre = 0,
-    t_post = np.inf
+    t_post = np.inf,
+    max_decay_fit_time=25.0
 )
 
 

--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -44,7 +44,7 @@ PARAM_RANGES = dict(
     max_predets = 3,
     t_pre = 0,
     t_post = np.inf,
-    max_decay_fit_time=25.0
+    max_decay_fit_time=25
 )
 
 

--- a/candidate_vetting/vet_kn_in_sn.py
+++ b/candidate_vetting/vet_kn_in_sn.py
@@ -42,7 +42,7 @@ PARAM_RANGES = dict(
     peak_time = [0, 35],
     decay_rate = [-0.1, 2.0],
     max_predets = 3,
-    t_pre = -0.1,
+    t_pre = -1.0,
     t_post = np.inf
 )
 

--- a/candidate_vetting/vet_kn_in_sn.py
+++ b/candidate_vetting/vet_kn_in_sn.py
@@ -44,7 +44,7 @@ PARAM_RANGES = dict(
     max_predets = 3,
     t_pre = -1.0,
     t_post = np.inf,
-    max_decay_fit_time=100.0,
+    max_decay_fit_time=100,
 )
 
 

--- a/candidate_vetting/vet_kn_in_sn.py
+++ b/candidate_vetting/vet_kn_in_sn.py
@@ -43,7 +43,8 @@ PARAM_RANGES = dict(
     decay_rate = [-0.1, 2.0],
     max_predets = 3,
     t_pre = -1.0,
-    t_post = np.inf
+    t_post = np.inf,
+    max_decay_fit_time=100.0,
 )
 
 

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -501,7 +501,8 @@ def _score_phot(allphot, target, nonlocalized_event,
             _model,_best_fit_params,max_time,decay_rate = estimate_max_find_decay_rate(
                 phot.dt,
                 phot.mag,
-                phot.magerr
+                phot.magerr,
+                max_decay_fit_time=param_ranges["max_decay_fit_time"]
             )
         except RuntimeError:
             logger.warning("Could not fit a power law or broken power law --> not setting peak_time or decay_rate")

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -264,7 +264,7 @@ def estimate_max_find_decay_rate(
         pl_ssr = _ssr(pl_model_y, mag_tofit)
         pl_info_crit = info_crit(pl_ssr, pl_nparams, len(mag_tofit))
 
-        bpl_model_y = _broken_powerlaw(dt_days, *bpl_popt)
+        bpl_model_y = _broken_powerlaw(dt_days_tofit, *bpl_popt)
         bpl_ssr = _ssr(bpl_model_y, mag_tofit)
         bpl_info_crit = info_crit(bpl_ssr, bpl_nparams, len(mag_tofit))
     else:
@@ -272,7 +272,7 @@ def estimate_max_find_decay_rate(
         bpl_info_crit = np.inf
         
     # now we can prefer the model with the lower AIC score
-    if (not pl_failed and bpl_failed) or (pl_info_crit < bpl_info_crit and not pl_failed):
+    if (not pl_failed and bpl_failed) or (not pl_failed and pl_info_crit < bpl_info_crit):
         logger.info("Powerlaw fits better")
         model = _powerlaw
         best_fit_params = pl_popt

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -202,9 +202,9 @@ def estimate_max_find_decay_rate(
     bpl_nparams = 4 # the degrees of freedom in a broken powerlaw model (y0, x0, s, m1, m2)
     
     curve_fit_kwargs = dict(
-        xdata = dt_days,
-        ydata = mag,
-        #sigma = magerr,
+        xdata = dt_days[dt_days <= max_decay_fit_time],
+        ydata = mag[dt_days <= max_decay_fit_time],
+        #sigma = magerr[dt_days <= max_decay_fit_time],
         absolute_sigma = True,
         maxfev = 5_000,
         ftol = 1e-8
@@ -455,6 +455,8 @@ def find_public_phot(
 def _score_phot(allphot, target, nonlocalized_event, 
                 param_ranges,
                 filt=None):
+    # allphot will have already been filtered not to extend beyond 
+    # param_ranges['t_post']
     if allphot is None: # this is if there is no photometry
         return 1, None, None, None, None, None
     

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -502,7 +502,8 @@ def _score_phot(allphot, target, nonlocalized_event,
 
     # then we can only do the next stuff if there is more than one photometry point
     # at this filter
-    if len(phot) > 1: # has to be at least 2 points to fit the powerlaw        
+    # has to be at least 2 points before max_decay_fit_time, to fit the powerlaw
+    if len(phot[phot.dt < param_ranges["max_decay_fit_time"]]) > 1:         
         # find the maximum and decay rate
         try:
             _model,_best_fit_params,max_time,decay_rate = estimate_max_find_decay_rate(

--- a/candidate_vetting/vet_super_kn.py
+++ b/candidate_vetting/vet_super_kn.py
@@ -42,7 +42,7 @@ PARAM_RANGES = dict(
     peak_time = [10, 70],
     decay_rate = [-np.inf, np.inf],
     max_predets = 3,
-    t_pre = -0.5,
+    t_pre = -1.0,
     t_post = np.inf
 )
 

--- a/candidate_vetting/vet_super_kn.py
+++ b/candidate_vetting/vet_super_kn.py
@@ -44,7 +44,7 @@ PARAM_RANGES = dict(
     max_predets = 3,
     t_pre = -1.0,
     t_post = np.inf,
-    max_decay_fit_time=100.0
+    max_decay_fit_time=100
 )
 
 

--- a/candidate_vetting/vet_super_kn.py
+++ b/candidate_vetting/vet_super_kn.py
@@ -43,7 +43,8 @@ PARAM_RANGES = dict(
     decay_rate = [-np.inf, np.inf],
     max_predets = 3,
     t_pre = -1.0,
-    t_post = np.inf
+    t_post = np.inf,
+    max_decay_fit_time=100.0
 )
 
 


### PR DESCRIPTION
2 changes;
- The time up until which pre-detections are allowed for KNe-in-SNe and super-KNe is extended from -0.1 day to -1.0 days for the former and -0.5 days to -1.0 days for the latter, to be more permissive. 
- `max_decay_fit_time`, which is supposed to set the time up until which we perform power law / broken power law fitting to, now actually impacts the fitting. `max_decay_fit_time` is now a transient-specific parameter. We set it to 25 days for classical KNe (following Rastinejad+24). I've set it to 100 days for KNe-in-SNe and super-KNe given their much slower decay rates. 

Previously, the only place `max_decay_fit_time` featured in `canndidate_vetting.vet_phot.estimate_max_find_decay_rate()` was when setting `xtest` to get the peak time:

```
    xtest = np.linspace(
        np.min(dt_days),
        np.max(dt_days),
        100*max_decay_fit_time
    )
```

It now features in several spots.

