### PR TITLE
Introduce SNR cutoff for photometry scoring

### DIFF
--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -632,7 +632,7 @@ def point_source_association(target_id:int, radius:float=2):
 
     return 1
 
-def associate_agn_2d(target_id:int, radius:float=2):
+def agn_association_2d(target_id:int, radius:float=2):
     """
     This searches the AGN catalogs for a match for this target
     """

--- a/candidate_vetting/vet_basic.py
+++ b/candidate_vetting/vet_basic.py
@@ -25,7 +25,7 @@ from tom_targets.models import TargetExtra
 from .vet import (
     point_source_association,
     host_association,
-    associate_agn_2d,
+    agn_association_2d,
     save_score_to_targetextra,
     HOST_DF_COLMAP_INVERSE
 )
@@ -64,7 +64,7 @@ def vet_basic(
         save_score_to_targetextra(target, "ps_score", ps_score)
 
     ## search for an AGN associated with the target
-    agn_df = associate_agn_2d(
+    agn_df = agn_association_2d(
         target_id, 
         radius=2 # 2 arcseconds
     )

--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -105,10 +105,10 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None,
                                   t_post=param_ranges["t_post"])
     phot_score, lum, max_time, decay_rate, _, _ = _score_phot(
         allphot=allphot,
-        target = target,
-        nonlocalized_event = nonlocalized_event,
+        target=target,
+        nonlocalized_event=nonlocalized_event,
         param_ranges=param_ranges,
-        filt = ["g", "r", "i", "o", "c"] # use the common optical filters
+        filt=["g", "r", "i", "o", "c"] # use the common optical filters
     )
     if lum is not None:
         update_score_factor(event_candidate, "phot_peak_lum", lum.value)

--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -44,7 +44,8 @@ PARAM_RANGES = dict(
     max_predets = 3,
     t_pre = 0,
     t_post = np.inf,
-    max_decay_fit_time=25
+    max_decay_fit_time=25,
+    phot_score_snr_min=5
 )
 
 

--- a/candidate_vetting/vet_kn_in_sn.py
+++ b/candidate_vetting/vet_kn_in_sn.py
@@ -105,10 +105,10 @@ def vet_kn_in_sn(target_id:int, nonlocalized_event_name:Optional[str]=None,
                                   t_post=param_ranges["t_post"])
     phot_score, lum, max_time, decay_rate, _, _ = _score_phot(
         allphot=allphot,
-        target = target,
-        nonlocalized_event = nonlocalized_event,
+        target=target,
+        nonlocalized_event=nonlocalized_event,
         param_ranges=param_ranges,
-        filt = ["g", "r", "i", "o", "c"] # use the common optical filters
+        filt=["g", "r", "i", "o", "c"] # use the common optical filters
     )
     if lum is not None:
         update_score_factor(event_candidate, "phot_peak_lum", lum.value)

--- a/candidate_vetting/vet_kn_in_sn.py
+++ b/candidate_vetting/vet_kn_in_sn.py
@@ -45,6 +45,7 @@ PARAM_RANGES = dict(
     t_pre = -1.0,
     t_post = np.inf,
     max_decay_fit_time=100,
+    phot_score_snr_min=5
 )
 
 

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -23,6 +23,8 @@ from candidate_vetting.tasks import async_atlas_query
 from .vet import (get_eventcandidate_default_distance, 
                   _distance_at_healpix)
 
+from custom_code.templatetags.photometry_extras import error_to_snr
+
 logger = logging.getLogger(__name__)
 
 FILTER_PRIORITY_ORDER = ["r", "g", "V", "R", "G"]
@@ -120,8 +122,11 @@ def _get_phot(target_id:int, nonlocalized_event:NonLocalizedEvent) -> pd.DataFra
         ).last().details["time"]
     ).mjd
     
-    # add a column to the dataframe
+    # add a dt column to the dataframe
     photdf["dt"] = photdf.mjd - gw_disc_date
+    
+    # add a SNR column to the dataframe
+    photdf["SNR"] = error_to_snr(photdf.magerr)
 
     return photdf
 

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -126,7 +126,7 @@ def _get_phot(target_id:int, nonlocalized_event:NonLocalizedEvent) -> pd.DataFra
     photdf["dt"] = photdf.mjd - gw_disc_date
     
     # add a SNR column to the dataframe
-    photdf["SNR"] = error_to_snr(photdf.magerr)
+    photdf["snr"] = error_to_snr(photdf.magerr)
 
     return photdf
 
@@ -465,12 +465,14 @@ def find_public_phot(
 def _score_phot(allphot, target, nonlocalized_event, 
                 param_ranges,
                 filt=None):
-    # allphot will have already been filtered not to extend beyond 
-    # param_ranges['t_post']
+    
     if allphot is None: # this is if there is no photometry
         return 1, None, None, None, None, None
     
+    # allphot will have already been filtered not to extend beyond param_ranges['t_post']
+    # we still need to toss out (1) upper limits (2) detections below a SNR threshold
     phot = allphot[~allphot.upperlimit]
+    phot = phot[phot.snr >= param_ranges["phot_score_snr_min"]]
     if not len(phot):
         # then there is no photometry for this object and we're done!
         return 1, None, None, None, None, None

--- a/candidate_vetting/vet_phot.py
+++ b/candidate_vetting/vet_phot.py
@@ -185,7 +185,7 @@ def estimate_max_find_decay_rate(
         A list/array of the magnitude errors since the GW discovery
     max_decay_fit_time: int
         The maximum time after the GW discovery in days that we should fit the decay to.
-        The default is 25 days based on discussion from Rastinejad+2024.
+        The default is 25 days based on discussion from Rastinejad+2022.
 
     RETURNS
     -------

--- a/candidate_vetting/vet_super_kn.py
+++ b/candidate_vetting/vet_super_kn.py
@@ -44,7 +44,8 @@ PARAM_RANGES = dict(
     max_predets = 3,
     t_pre = -1.0,
     t_post = np.inf,
-    max_decay_fit_time=100
+    max_decay_fit_time=100,
+    phot_score_snr_min=5
 )
 
 

--- a/candidate_vetting/vet_super_kn.py
+++ b/candidate_vetting/vet_super_kn.py
@@ -105,10 +105,10 @@ def vet_super_kn(target_id:int, nonlocalized_event_name:Optional[str]=None,
                                   t_post=param_ranges["t_post"])
     phot_score, lum, max_time, decay_rate, _, _ = _score_phot(
         allphot=allphot,
-        target = target,
-        nonlocalized_event = nonlocalized_event,
+        target=target,
+        nonlocalized_event=nonlocalized_event,
         param_ranges=param_ranges,
-        filt = ["g", "r", "i", "o", "c"] # use the common optical filters
+        filt=["g", "r", "i", "o", "c"] # use the common optical filters
     )
     if lum is not None:
         update_score_factor(event_candidate, "phot_peak_lum", lum.value)


### PR DESCRIPTION
This PR introduces filtering in `candidate_vetting.vet_phot._score_phot()` to exclude photometry below a certain SNR when obtaining peak luminosities, rise times, and decay rates for the purposes of photometry scoring. The user can set this SNR threshold as one of the parameters input into `vet_bns`, `vet_kn_in_sn`, `vet_super_kn`, etc.

This is set to a default of 5.0 right now, for all transients.

Tested this by running just photometry scoring on all candidates, see code snippet below.

Also tidied up code in a couple other places and made the name of the 2D AGN association function more consistent with the host galaxy association function.

