### PR TITLE
Update Minor Planet Center (MPC) checking framework

### DIFF
--- a/candidate_vetting/vet_basic.py
+++ b/candidate_vetting/vet_basic.py
@@ -13,9 +13,11 @@ This should also be called before any photometry vetting in the NLE-related
 vetting modules. That way we can reduce the code duplication between them!
 """
 
+
 import logging
 import io
 from astropy.time import Time
+import numpy as np
 import pandas as pd
 
 from trove_targets.models import Target
@@ -76,11 +78,26 @@ def vet_basic(
             data_type="photometry",
             value__magnitude__isnull=False
         )
-        if phot.exists():
+        # get photometry, throwing out limiting mags, phot with no error, and phot with SNR < 5
+        phot = ReducedDatum.objects.filter(
+            target_id=target_id,
+            data_type="photometry",
+            value__magnitude__isnull=False,
+            value__error__isnull=False,
+            value__error__lte=2.5/np.log(10)/5
+        )
+        # if more than (5-sigma) 1 detection, likely not a MPC object
+        if phot.exists() and len(phot) > 1:
+            logger.warn("This candidate has more than 1 >5-sigma detection, "+
+                        "skipping MPC!")
+            mpc_match = None
+        # if only 1 detection, run MPC match
+        elif phot.exists() and len(phot) == 1:
             latest_det = phot.latest()
             date = Time(latest_det.timestamp).mjd
             t = Transient(target.ra, target.dec)
             mpc_match = t.minor_planet_match(date)
+        # no detections --> can't do MPC match
         else:
             logger.warn("This candidate has no photometry, skipping MPC!")
             mpc_match = None

--- a/candidate_vetting/vet_basic.py
+++ b/candidate_vetting/vet_basic.py
@@ -73,11 +73,6 @@ def vet_basic(
         
     ## run the minor planet checker
     if overwrite or not te.filter(key="mpc_match_name").exists():
-        phot = ReducedDatum.objects.filter(
-            target_id=target_id,
-            data_type="photometry",
-            value__magnitude__isnull=False
-        )
         # get photometry, throwing out limiting mags, phot with no error, and phot with SNR < 5
         phot = ReducedDatum.objects.filter(
             target_id=target_id,


### PR DESCRIPTION
The new workflow is as follows: First, we pull out all photometry which is not a limiting magnitude, has an error, and has a SNR of >5. Then:
1. If the number of photmetry points is >1, likely not an asteroid, skip MPC checking (assign MPC score = 1)
2. If the number of photometry points is precisely 1, pass this detection into the MCP checker 
3. If the number of photometry points is precisely 0, skip MPC checking (assign MPC score = 1) 

That last condition (3) was already in place. Checking the number of detections is new. 

An unintended bonus of this new workflow is that MPC checking, which is the slowest step in vetting, will now be skipped for any candidates with more than one significant detection! 

Example to test:

```
from tqdm import tqdm
from tom_nonlocalizedevents.models import EventCandidate, NonLocalizedEvent 
from candidate_vetting.vet_basic import vet_basic


# create nonlocalized event, event candidates
nle = NonLocalizedEvent.objects.filter(id="20113")[0] # 20113 is 251112cm, see the URL for it
ecs = EventCandidate.objects.filter(nonlocalizedevent_id = nle.id
                                    ).order_by('target__name')

# iterate through all event candidates
for i in tqdm(range(len(ecs))):
    ec_i = ecs[i]
    
    # run basic vetting
    vet_basic(target_id=ec_i.target.id, 
              overwrite=True)
```

That `tqdm` is not necessary, but provides a progress bar for the test since it might take a while.