### PR TITLE
If t_post is given, use it to choose the localization skymap

### DIFF
--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -31,7 +31,6 @@ from trove_targets.models import Target
 from tom_dataproducts.models import ReducedDatum
 from tom_nonlocalizedevents.models import (
     EventCandidate,
-    EventLocalization,
     NonLocalizedEvent,
     EventSequence
 )

--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -4,7 +4,7 @@ their resemblance to kilonovae.
 """
 import logging
 from typing import Optional
-from astropy.time import Time
+from astropy.time import Time, TimeDelta
 from astropy import units as u
 import pandas as pd
 import numpy as np
@@ -31,6 +31,7 @@ from trove_targets.models import Target
 from tom_dataproducts.models import ReducedDatum
 from tom_nonlocalizedevents.models import (
     EventCandidate,
+    EventLocalization,
     NonLocalizedEvent,
     EventSequence
 )
@@ -63,7 +64,16 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None,
     target = Target.objects.get(id=target_id)
     
     ## check skymap association
-    skymap_score = skymap_association(nonlocalized_event_name, target_id)
+    # first, get the time
+    if np.isfinite(param_ranges["t_post"]):
+        locs = EventLocalization.objects.filter(nonlocalizedevent_id=nonlocalized_event.id)
+        nle_time = locs[0].date
+        max_time = Time(nle_time) + TimeDelta(param_ranges["t_post"]*u.day)
+    else: # just use current time
+        max_time = Time.now()
+    # then, get the score
+    skymap_score = skymap_association(nonlocalized_event_name, target_id,
+                                      max_time=max_time)
     update_score_factor(event_candidate, "skymap_score", skymap_score)
     if skymap_score < 1e-2:
         return 

--- a/candidate_vetting/vet_bns.py
+++ b/candidate_vetting/vet_bns.py
@@ -64,14 +64,12 @@ def vet_bns(target_id:int, nonlocalized_event_name:Optional[str]=None,
     target = Target.objects.get(id=target_id)
     
     ## check skymap association
-    # first, get the time
     if np.isfinite(param_ranges["t_post"]):
-        locs = EventLocalization.objects.filter(nonlocalizedevent_id=nonlocalized_event.id)
-        nle_time = locs[0].date
-        max_time = Time(nle_time) + TimeDelta(param_ranges["t_post"]*u.day)
+        gw_disc_date = EventSequence.objects.filter( # GW discovery time
+            nonlocalizedevent_id=nonlocalized_event.id).last().details["time"]
+        max_time = Time(gw_disc_date) + TimeDelta(param_ranges["t_post"]*u.day)
     else: # just use current time
         max_time = Time.now()
-    # then, get the score
     skymap_score = skymap_association(nonlocalized_event_name, target_id,
                                       max_time=max_time)
     update_score_factor(event_candidate, "skymap_score", skymap_score)

--- a/candidate_vetting/vet_kn_in_sn.py
+++ b/candidate_vetting/vet_kn_in_sn.py
@@ -64,14 +64,12 @@ def vet_kn_in_sn(target_id:int, nonlocalized_event_name:Optional[str]=None,
     target = Target.objects.get(id=target_id)
     
     ## check skymap association
-    # first, get the time
     if np.isfinite(param_ranges["t_post"]):
-        locs = EventLocalization.objects.filter(nonlocalizedevent_id=nonlocalized_event.id)
-        nle_time = locs[0].date
-        max_time = Time(nle_time) + TimeDelta(param_ranges["t_post"]*u.day)
+        gw_disc_date = EventSequence.objects.filter( # GW discovery time
+            nonlocalizedevent_id=nonlocalized_event.id).last().details["time"]
+        max_time = Time(gw_disc_date) + TimeDelta(param_ranges["t_post"]*u.day)
     else: # just use current time
         max_time = Time.now()
-    # then, get the score
     skymap_score = skymap_association(nonlocalized_event_name, target_id,
                                       max_time=max_time)
     update_score_factor(event_candidate, "skymap_score", skymap_score)

--- a/candidate_vetting/vet_kn_in_sn.py
+++ b/candidate_vetting/vet_kn_in_sn.py
@@ -4,7 +4,7 @@ their resemblance to kilonovae-in-supernovae.
 """
 import logging
 from typing import Optional
-from astropy.time import Time
+from astropy.time import Time, TimeDelta
 from astropy import units as u
 import pandas as pd
 import numpy as np
@@ -31,6 +31,7 @@ from trove_targets.models import Target
 from tom_dataproducts.models import ReducedDatum
 from tom_nonlocalizedevents.models import (
     EventCandidate,
+    EventLocalization,
     NonLocalizedEvent,
     EventSequence
 )
@@ -63,7 +64,16 @@ def vet_kn_in_sn(target_id:int, nonlocalized_event_name:Optional[str]=None,
     target = Target.objects.get(id=target_id)
     
     ## check skymap association
-    skymap_score = skymap_association(nonlocalized_event_name, target_id)
+    # first, get the time
+    if np.isfinite(param_ranges["t_post"]):
+        locs = EventLocalization.objects.filter(nonlocalizedevent_id=nonlocalized_event.id)
+        nle_time = locs[0].date
+        max_time = Time(nle_time) + TimeDelta(param_ranges["t_post"]*u.day)
+    else: # just use current time
+        max_time = Time.now()
+    # then, get the score
+    skymap_score = skymap_association(nonlocalized_event_name, target_id,
+                                      max_time=max_time)
     update_score_factor(event_candidate, "skymap_score", skymap_score)
     if skymap_score < 1e-2:
         return 

--- a/candidate_vetting/vet_kn_in_sn.py
+++ b/candidate_vetting/vet_kn_in_sn.py
@@ -31,7 +31,6 @@ from trove_targets.models import Target
 from tom_dataproducts.models import ReducedDatum
 from tom_nonlocalizedevents.models import (
     EventCandidate,
-    EventLocalization,
     NonLocalizedEvent,
     EventSequence
 )

--- a/candidate_vetting/vet_super_kn.py
+++ b/candidate_vetting/vet_super_kn.py
@@ -64,14 +64,12 @@ def vet_super_kn(target_id:int, nonlocalized_event_name:Optional[str]=None,
     target = Target.objects.get(id=target_id)
     
     ## check skymap association
-    # first, get the time
     if np.isfinite(param_ranges["t_post"]):
-        locs = EventLocalization.objects.filter(nonlocalizedevent_id=nonlocalized_event.id)
-        nle_time = locs[0].date
-        max_time = Time(nle_time) + TimeDelta(param_ranges["t_post"]*u.day)
+        gw_disc_date = EventSequence.objects.filter( # GW discovery time
+            nonlocalizedevent_id=nonlocalized_event.id).last().details["time"]
+        max_time = Time(gw_disc_date) + TimeDelta(param_ranges["t_post"]*u.day)
     else: # just use current time
         max_time = Time.now()
-    # then, get the score
     skymap_score = skymap_association(nonlocalized_event_name, target_id,
                                       max_time=max_time)
     update_score_factor(event_candidate, "skymap_score", skymap_score)

--- a/candidate_vetting/vet_super_kn.py
+++ b/candidate_vetting/vet_super_kn.py
@@ -31,7 +31,6 @@ from trove_targets.models import Target
 from tom_dataproducts.models import ReducedDatum
 from tom_nonlocalizedevents.models import (
     EventCandidate,
-    EventLocalization,
     NonLocalizedEvent,
     EventSequence
 )

--- a/candidate_vetting/vet_super_kn.py
+++ b/candidate_vetting/vet_super_kn.py
@@ -4,7 +4,7 @@ their resemblance to super-kilonovae.
 """
 import logging
 from typing import Optional
-from astropy.time import Time
+from astropy.time import Time, TimeDelta
 from astropy import units as u
 import pandas as pd
 import numpy as np
@@ -31,6 +31,7 @@ from trove_targets.models import Target
 from tom_dataproducts.models import ReducedDatum
 from tom_nonlocalizedevents.models import (
     EventCandidate,
+    EventLocalization,
     NonLocalizedEvent,
     EventSequence
 )
@@ -63,7 +64,16 @@ def vet_super_kn(target_id:int, nonlocalized_event_name:Optional[str]=None,
     target = Target.objects.get(id=target_id)
     
     ## check skymap association
-    skymap_score = skymap_association(nonlocalized_event_name, target_id)
+    # first, get the time
+    if np.isfinite(param_ranges["t_post"]):
+        locs = EventLocalization.objects.filter(nonlocalizedevent_id=nonlocalized_event.id)
+        nle_time = locs[0].date
+        max_time = Time(nle_time) + TimeDelta(param_ranges["t_post"]*u.day)
+    else: # just use current time
+        max_time = Time.now()
+    # then, get the score
+    skymap_score = skymap_association(nonlocalized_event_name, target_id,
+                                      max_time=max_time)
     update_score_factor(event_candidate, "skymap_score", skymap_score)
     if skymap_score < 1e-2:
         return 


### PR DESCRIPTION
When tpost is passed as a parameter for vetting, use it to select which skymap to use. Small changes to `vet_bns`, `vet_kn-in-sn`, and `vet_super-kn`.