### PR TITLE
Require prob_galaxy less than 0.7 when constructing PS1 point source catalog

### DIFF
--- a/candidate_vetting/public_catalogs/static_catalogs.py
+++ b/candidate_vetting/public_catalogs/static_catalogs.py
@@ -399,7 +399,8 @@ class Ps1PointSource(Ps1):
     def query(self, ra, dec, radius=RADIUS_ARCSEC):
         query_set = super().query(ra, dec, radius)
         return query_set.filter(
-            ps_score__gt = PS1_POINT_SOURCE_THRESHOLD
+            ps_score__gt = PS1_POINT_SOURCE_THRESHOLD,
+            prob_galaxy__lt = 0.7
         )
     
 class RomaBzcat(StaticCatalog):


### PR DESCRIPTION
This avoids including galaxies when constructing the PS1 *point source* catalog. 

Addresses issue #34 .