### PR TITLE
Check len(new_candidates) before updating credible regions for an empty list of candidates

### DIFF
--- a/custom_code/healpix_utils.py
+++ b/custom_code/healpix_utils.py
@@ -85,9 +85,10 @@ def create_candidates_from_targets(eventsequence, prob=0.95, target_ids=None):
 
         logger.info(f'Linked {len(new_candidates)} new candidates to event {eventsequence.nonlocalizedevent.event_id}')
 
-        localizations = eventsequence.nonlocalizedevent.localizations.all()
-        for localization in localizations:
-            update_all_credible_region_percents_for_candidates(localization, [cand.id for cand in new_candidates])
+        if len(new_candidates): # only do this (time-consuming) step if any new candidates were linked
+            localizations = eventsequence.nonlocalizedevent.localizations.all()
+            for localization in localizations:
+                update_all_credible_region_percents_for_candidates(localization, [cand.id for cand in new_candidates])
 
         return new_candidates
 


### PR DESCRIPTION
First, outlining steps that currently occur:
- When ingesting targets with TNS, when at the stage of associating targets with NLEs, we call `custom_code.alertstream_handlers.vet_or_post_error()` on targets not in the base target table
- `vet_or_post_error()` in turn calls `custom_code.hooks.target_post_save()`
- `target_post_save()` in turn calls `custom_code.hooks.associate_nle_with_target()`
- `associate_nle_with_target()` in turn calls `custom_code.healpix_utils.create_candidates_from_targets()`
- `create_candidates_from_targets()` in turn calls `tom_nonlocalizedevents.healpix_utils.update_all_credible_region_percents_for_candidates()`

However, if you pass an empty list of candidates to `update_all_credible_region_percents_for_candidates()`, it loops through all candidates associated with an NLE and updates their credible region percentages, per localization. This is time-consuming and not necessary. So, this fix only bothers with that updating if there are any new candidates to begin with.

Small fix but wanted to make sure it won't break anything!