### PR TITLE
Update target create form

### DIFF
--- a/custom_code/templatetags/target_extras.py
+++ b/custom_code/templatetags/target_extras.py
@@ -35,7 +35,6 @@ def split_name(name):
         name_info['tns_objname'] = None
     return name_info
 
-
 @register.inclusion_tag('tom_targets/partials/aladin_custom.html')
 def aladin_custom(target):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ whitenoise
 trove_mpc @ git+https://github.com/astro-trove/trove-mpc.git
 fundamentals
 skypatrol
+django-autocomplete-light

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -301,6 +301,10 @@ AUTH_STRATEGY = 'READ_ONLY'
 # `ObservationRecord`, `DataProduct`, and `ReducedDatum` objects.
 TARGET_PERMISSIONS_ONLY = True
 
+# Default permission for newly created targets. Values can be 'PRIVATE', 'PUBLIC', or 'OPEN'
+# Any new target created will be public (visible by anyone signed in)
+TARGET_DEFAULT_PERMISSION = 'PUBLIC'
+
 # URLs that should be allowed access even with AUTH_STRATEGY = LOCKED
 # for example: OPEN_URLS = ['/', '/about']
 OPEN_URLS = ['/accounts/register/']

--- a/saguaro_tom/settings.py
+++ b/saguaro_tom/settings.py
@@ -68,6 +68,8 @@ INSTALLED_APPS = [
     'candidate_vetting',
     'trove_targets',
     'trove_nonlocalizedevents',
+    'dal',
+    'dal_select2'
 ]
 
 SITE_ID=1

--- a/saguaro_tom/urls.py
+++ b/saguaro_tom/urls.py
@@ -18,6 +18,7 @@ from .api import api
 
 urlpatterns = [
     path('', include('custom_code.urls')),
+    path("targets/", include("trove_targets.urls", namespace="trove_targets")),
     path('', include('tom_common.urls')),
     path('', include('candidate_vetting.urls')),
     path('nonlocalizedevents/', include('tom_nonlocalizedevents.urls', namespace='nonlocalizedevents')),

--- a/templates/tom_targets/partials/target_buttons.html
+++ b/templates/tom_targets/partials/target_buttons.html
@@ -1,16 +1,26 @@
 {% load targets_extras target_extras %}
 {% with target.name|split_name as name %}
+
 {% if name.tns_objname %}
-    <a href="{% url 'custom_code:classify' pk=target.id %}" title="Classify target on TNS" class="btn btn-secondary">Classify</a>
+<a href="{% url 'custom_code:classify' pk=target.id %}" title="Classify target on TNS" class="btn btn-secondary">Classify</a>
+{% comment %}
 {% else %}
-    <a href="{% url 'custom_code:report' pk=target.id %}" title="Report target to TNS" class="btn btn-secondary">Report</a>
+    {% if request.user.is_superuser %}
+        <a href="{% url 'custom_code:report' pk=target.id %}" title="Report target to TNS" class="btn btn-secondary">Report</a>
+	{% endif %}
+{% endcomment %}
 {% endif %}
 {% endwith %}
+
 <a href="{% url 'tom_targets:update' pk=target.id %}" title="Edit target details" class="btn btn-primary">Edit</a>
-{% if sharing %}
+
+{% comment %}
     <a href="{% url 'tom_targets:share' pk=target.id %}" title="Share target" class="btn btn-info">Share</a>
-{% endif %}
-<a href="{% url 'tom_targets:delete' pk=target.id %}" title="Delete target" class="btn btn-danger">Delete</a>
+{% endcomment %}
+
+{# if request.user.is_superuser #}
+    <a href="{% url 'tom_targets:delete' pk=target.id %}" title="Delete target" class="btn btn-danger">Delete</a>
+{# endif #}
 <a href="{% url 'candidate_vetting:checknewphot' pk=target.id %}" title="Check for new data" class="btn btn-warning">Update Lightcurve</a>
 <a href="{% url 'candidate_vetting:updatez' pk=target.id %}" title="Update a potential host galaxy's redshift" class="btn btn-success">Update Host z</a>
 

--- a/templates/trove_targets/custom_target_create_form.html
+++ b/templates/trove_targets/custom_target_create_form.html
@@ -18,36 +18,6 @@
 {% bootstrap_form_errors form %}
 <form method="post" class="form">
 {% csrf_token %}
-{% bootstrap_field form.type %}
-
-{% comment %}
-
-<div class="form-row">
-    <div class="col">
-        {% bootstrap_field form.name size="large" show_help=False %}
-    </div>
-</div>
-
-<div class="row" x-data="{open: false}">
-    <div class="col mb-2">
-        <span @click="open = ! open" class="text-primary pointer" x-text="open ? '▾ Aliases' : '▸ Aliases'"></span>
-        <div x-show="open" class="border p-3 bg-light" x-transition>
-            {% bootstrap_formset_errors names_form %}
-            {% bootstrap_formset names_form %}
-        </div>
-    </div>
-</div>
-<div class="row" x-data="{open: false}">
-    <div class="col mb-2">
-        <span @click="open = ! open" class="text-primary pointer" x-text="open ? '▾ Tags' : '▸ Tags'"></span>
-        <div x-show="open" class="border p-3 bg-light" x-transition>
-            {% bootstrap_formset_errors extra_form %}
-            {% bootstrap_formset extra_form %}
-        </div>
-    </div>
-</div>
-{% endcomment %}
-
 {% bootstrap_field form.name %}
 {% bootstrap_field form.ra %}
 {% bootstrap_field form.dec %}
@@ -56,10 +26,12 @@
 {% bootstrap_field form.distance_err %}
 {% bootstrap_field form.classification %}
 {% bootstrap_field form.redshift %}
-{% bootstrap_field form.type hidden=True %}  {# you probably want type hidden #}
+{% bootstrap_field form.type hidden=True %}
 
-{# crispy form #}
+{% bootstrap_form_errors target_nle_form %}
+{% bootstrap_form target_nle_form %}
 
+{% comment %}
 <div class="row" x-data="{open: false}">
     <div class="col mb-2">
         <span @click="open = ! open" class="text-primary pointer" x-text="open ? '▾ Aliases' : '▸ Aliases'"></span>
@@ -69,43 +41,14 @@
         </div>
     </div>
 </div>
-
-
-{% comment %}
-<h4>Permissions</h4>
-<div class="row mb-3" x-data="{permission: '{{ form.permissions.value }}' }">
-    <div class="col-md-6">
-        <select x-model="permission" name="permissions" class="form-control" id="id_permissions">
-          <option value="OPEN">Open</option>
-          <option value="PUBLIC">Public</option>
-          <option value="PRIVATE">Private</option>
-        </select>
-        <div class="form-text text-muted">
-          <small>Open: Targets will be visible to all users, even if not logged-in.<br/>
-          Public: Targets will be visible to all logged in users.<br/>
-          Private: Targets will be visible only to members of the selected groups.</small>
-        </div>
-    </div>
-    <div class="col-md-6">
-        <div x-show="permission == 'PRIVATE'" x-transition>
-            <span>Target will only be visibile to members of these groups:</span>
-            {% bootstrap_field form.groups show_label=False %}
-            {% if not request.user.groups.exists %}
-                <p class="text-muted">No groups have been created.<br/>
-                  <a href="{% url 'group-create' %}">Create groups.</a>
-                </p>
-            {% endif %}
-        </div>
-    </div>
-</div>
 {% endcomment %}
 
 {% if not object %}
   <button type="submit" formaction="{% url 'targets:create' %}" class="btn btn-primary">Submit</button>
-  {% else %}
+{% else %}
   <button type="submit" formaction="{% url 'targets:update' pk=object.id %}" class="btn btn-primary">Save</button>
   <a href="{% url 'targets:detail' pk=object.id %}" class="btn btn-primary" title="Back">Back</a>
-  {% endif %}
+{% endif %}
 </form>
 
 {{ target_nle_form.media }}

--- a/templates/trove_targets/custom_target_create_form.html
+++ b/templates/trove_targets/custom_target_create_form.html
@@ -1,5 +1,6 @@
 {% extends 'tom_common/base.html' %}
 {% load bootstrap4 targets_extras crispy_forms_tags %}
+
 {% block title %}New Target{% endblock %}
 {% block content %}
 {% if not object %}
@@ -18,24 +19,15 @@
 <form method="post" class="form">
 {% csrf_token %}
 {% bootstrap_field form.type %}
+
+{% comment %}
+
 <div class="form-row">
     <div class="col">
         {% bootstrap_field form.name size="large" show_help=False %}
     </div>
 </div>
 
-<div class="row" x-data="{open: false}">
-    <div class="col mb-2">
-        <span @click="open = ! open" class="text-primary pointer" x-text="open ? '▾ Aliases' : '▸ Aliases'"></span>
-        <div x-show="open" class="border p-3 bg-light" x-transition>
-	    {% bootstrap_form_errors target_nle_form %}
-            {% bootstrap_form target_nle_form %}
-        </div>
-    </div>
-</div>
-
-
-{% comment %}
 <div class="row" x-data="{open: false}">
     <div class="col mb-2">
         <span @click="open = ! open" class="text-primary pointer" x-text="open ? '▾ Aliases' : '▸ Aliases'"></span>
@@ -56,7 +48,24 @@
 </div>
 {% endcomment %}
 
-{% crispy form %}
+{% bootstrap_field form.name %}
+{% bootstrap_field form.ra %}
+{% bootstrap_field form.dec %}
+{% bootstrap_field form.epoch %}
+{% bootstrap_field form.type hidden=True %}  {# you probably want type hidden #}
+
+{# crispy form #}
+
+<div class="row" x-data="{open: false}">
+    <div class="col mb-2">
+        <span @click="open = ! open" class="text-primary pointer" x-text="open ? '▾ Aliases' : '▸ Aliases'"></span>
+        <div x-show="open" class="border p-3 bg-light" x-transition>
+	    {% bootstrap_form_errors target_nle_form %}
+            {% bootstrap_form target_nle_form %}
+        </div>
+    </div>
+</div>
+
 
 {% comment %}
 <h4>Permissions</h4>

--- a/templates/trove_targets/custom_target_create_form.html
+++ b/templates/trove_targets/custom_target_create_form.html
@@ -4,7 +4,7 @@
 {% block title %}New Target{% endblock %}
 {% block content %}
 {% if not object %}
-  <h3>Create a Target TEST</h3>
+  <h3>Create a Target</h3>
   <ul class="nav nav-tabs mb-2">
     {% for k, v in type_choices %}
       <li class="nav-item">
@@ -52,6 +52,10 @@
 {% bootstrap_field form.ra %}
 {% bootstrap_field form.dec %}
 {% bootstrap_field form.epoch %}
+{% bootstrap_field form.distance %}
+{% bootstrap_field form.distance_err %}
+{% bootstrap_field form.classification %}
+{% bootstrap_field form.redshift %}
 {% bootstrap_field form.type hidden=True %}  {# you probably want type hidden #}
 
 {# crispy form #}

--- a/templates/trove_targets/custom_target_create_form.html
+++ b/templates/trove_targets/custom_target_create_form.html
@@ -1,0 +1,100 @@
+{% extends 'tom_common/base.html' %}
+{% load bootstrap4 targets_extras crispy_forms_tags %}
+{% block title %}New Target{% endblock %}
+{% block content %}
+{% if not object %}
+  <h3>Create a Target TEST</h3>
+  <ul class="nav nav-tabs mb-2">
+    {% for k, v in type_choices %}
+      <li class="nav-item">
+        <a class="nav-link {% if form.type.initial == k %} active {% endif %}" href="{% url 'targets:create' %}?type={{ k }}">{{ v  }}</a>
+      </li>
+    {% endfor %}
+{% else %}
+<h3> Update {{ object.name }}</h3>
+{% endif %}
+</ul>
+{% bootstrap_form_errors form %}
+<form method="post" class="form">
+{% csrf_token %}
+{% bootstrap_field form.type %}
+<div class="form-row">
+    <div class="col">
+        {% bootstrap_field form.name size="large" show_help=False %}
+    </div>
+</div>
+
+<div class="row" x-data="{open: false}">
+    <div class="col mb-2">
+        <span @click="open = ! open" class="text-primary pointer" x-text="open ? '▾ Aliases' : '▸ Aliases'"></span>
+        <div x-show="open" class="border p-3 bg-light" x-transition>
+	    {% bootstrap_form_errors target_nle_form %}
+            {% bootstrap_form target_nle_form %}
+        </div>
+    </div>
+</div>
+
+
+{% comment %}
+<div class="row" x-data="{open: false}">
+    <div class="col mb-2">
+        <span @click="open = ! open" class="text-primary pointer" x-text="open ? '▾ Aliases' : '▸ Aliases'"></span>
+        <div x-show="open" class="border p-3 bg-light" x-transition>
+            {% bootstrap_formset_errors names_form %}
+            {% bootstrap_formset names_form %}
+        </div>
+    </div>
+</div>
+<div class="row" x-data="{open: false}">
+    <div class="col mb-2">
+        <span @click="open = ! open" class="text-primary pointer" x-text="open ? '▾ Tags' : '▸ Tags'"></span>
+        <div x-show="open" class="border p-3 bg-light" x-transition>
+            {% bootstrap_formset_errors extra_form %}
+            {% bootstrap_formset extra_form %}
+        </div>
+    </div>
+</div>
+{% endcomment %}
+
+{% crispy form %}
+
+{% comment %}
+<h4>Permissions</h4>
+<div class="row mb-3" x-data="{permission: '{{ form.permissions.value }}' }">
+    <div class="col-md-6">
+        <select x-model="permission" name="permissions" class="form-control" id="id_permissions">
+          <option value="OPEN">Open</option>
+          <option value="PUBLIC">Public</option>
+          <option value="PRIVATE">Private</option>
+        </select>
+        <div class="form-text text-muted">
+          <small>Open: Targets will be visible to all users, even if not logged-in.<br/>
+          Public: Targets will be visible to all logged in users.<br/>
+          Private: Targets will be visible only to members of the selected groups.</small>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div x-show="permission == 'PRIVATE'" x-transition>
+            <span>Target will only be visibile to members of these groups:</span>
+            {% bootstrap_field form.groups show_label=False %}
+            {% if not request.user.groups.exists %}
+                <p class="text-muted">No groups have been created.<br/>
+                  <a href="{% url 'group-create' %}">Create groups.</a>
+                </p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endcomment %}
+
+{% if not object %}
+  <button type="submit" formaction="{% url 'targets:create' %}" class="btn btn-primary">Submit</button>
+  {% else %}
+  <button type="submit" formaction="{% url 'targets:update' pk=object.id %}" class="btn btn-primary">Save</button>
+  <a href="{% url 'targets:detail' pk=object.id %}" class="btn btn-primary" title="Back">Back</a>
+  {% endif %}
+</form>
+
+{{ target_nle_form.media }}
+
+{% endblock %}

--- a/trove_targets/forms.py
+++ b/trove_targets/forms.py
@@ -1,0 +1,18 @@
+from django import forms
+
+from tom_nonlocalizedevents.models import NonLocalizedEvent
+from dal import autocomplete
+
+class TargetNLEForm(forms.Form):
+    nle_select = forms.ModelChoiceField(
+        queryset=NonLocalizedEvent.objects.all(),
+        label="Choose a poorly localized event",
+        required=True,
+        widget=autocomplete.ModelSelect2(
+            url='trove_targets:nonlocalizedevent-autocomplete',
+            attrs={
+                'data-placeholder': 'Start typing to search...',
+                'data-minimum-input-length': 1,
+            }
+        )
+    )

--- a/trove_targets/forms.py
+++ b/trove_targets/forms.py
@@ -1,6 +1,11 @@
 from django import forms
 
 from tom_nonlocalizedevents.models import NonLocalizedEvent
+from tom_targets.forms import TargetForm, SiderealTargetCreateForm
+#from tom_targets.models import Target
+from trove_targets.models import Target
+from tom_targets.base_models import REQUIRED_SIDEREAL_FIELDS
+
 from dal import autocomplete
 
 class TargetNLEForm(forms.Form):
@@ -16,3 +21,15 @@ class TargetNLEForm(forms.Form):
             }
         )
     )
+    
+class CustomSiderealTargetCreateForm(SiderealTargetCreateForm):
+
+    def __init__(self, *args, **kwargs):
+        super(TargetForm, self).__init__(*args, **kwargs)
+        for field in REQUIRED_SIDEREAL_FIELDS:
+            self.fields[field].required = True
+
+    
+    class Meta(SiderealTargetCreateForm.Meta):
+        fields = ['name', 'ra', 'dec', 'epoch', 'distance', 'distance_err', 'type',
+                  'parallax', 'classification', 'redshift']

--- a/trove_targets/urls.py
+++ b/trove_targets/urls.py
@@ -1,0 +1,14 @@
+from django.urls import path
+from .views import CustomTargetCreateView, NLEAutocompleteView
+
+app_name = 'trove_targets'
+
+urlpatterns = [
+    path('create/', CustomTargetCreateView.as_view(), name='create'),
+    path(
+        'nonlocalizedevent-autocomplete/',
+        NLEAutocompleteView.as_view(),
+        name='nonlocalizedevent-autocomplete'
+    ),
+    # ... other urls
+]

--- a/trove_targets/views.py
+++ b/trove_targets/views.py
@@ -2,12 +2,13 @@ import logging
 
 from django.shortcuts import render, redirect
 from django.views.generic.edit import CreateView
+from django.conf import settings
 from dal import autocomplete
 
 from tom_common.hooks import run_hook
 
 from tom_targets.views import TargetCreateView
-from tom_targets.models import Target
+from tom_targets.models import BaseTarget, Target
 from tom_targets.forms import TargetForm, SiderealTargetCreateForm
 
 from tom_nonlocalizedevents.models import NonLocalizedEvent, EventCandidate
@@ -15,6 +16,12 @@ from tom_nonlocalizedevents.models import NonLocalizedEvent, EventCandidate
 from .forms import TargetNLEForm, CustomSiderealTargetCreateForm
 
 logger = logging.getLogger(__name__)
+
+PERMISSIONS_MAP = {
+    "PUBLIC": BaseTarget.Permissions.PUBLIC,
+    "PRIVATE": BaseTarget.Permissions.PRIVATE,
+    "OPEN": BaseTarget.Permissions.OPEN
+}
 
 class NLEAutocompleteView(autocomplete.Select2QuerySetView):
 
@@ -83,6 +90,12 @@ class CustomTargetCreateView(TargetCreateView):
 
         # Give the user access to the target they created
         self.object.give_user_access(self.request.user)
+
+        # then also set the global permission group of the object to the default
+        # TODO: If we ever change the permissions functionality and allow users to set
+        #       permissions on upload, we need to change this!
+        self.object.permissions = PERMISSIONS_MAP[settings.TARGET_DEFAULT_PERMISSION]
+        self.object.save()
 
         # Run the target post save hook
         logger.info('Target post save hook: %s created: %s', target, True)

--- a/trove_targets/views.py
+++ b/trove_targets/views.py
@@ -1,3 +1,85 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.views.generic.edit import CreateView
+from tom_targets.views import TargetCreateView
+from tom_targets.models import Target
+from .forms import TargetNLEForm
 
-# Create your views here.
+from dal import autocomplete
+from tom_nonlocalizedevents.models import NonLocalizedEvent
+
+class NLEAutocompleteView(autocomplete.Select2QuerySetView):
+
+    def get_queryset(self):
+        qs = NonLocalizedEvent.objects.all()
+
+        print(f"DEBUG: self.q = {self.q}")
+        print(f"DEBUG: queryset count = {qs.count()}")
+        if self.q:
+            # Simple case-insensitive search on the name field
+            qs = qs.filter(event_id__icontains=self.q)
+        
+        return qs
+
+class CustomTargetCreateView(TargetCreateView):
+    template_name = 'trove_targets/custom_target_create_form.html'
+
+    def get_context_data(self, **kwargs):
+        """
+        Inserts certain form data into the context dict.
+
+        :returns: Dictionary with the following keys:
+
+                  `type_choices`: ``tuple``: Tuple of 2-tuples of strings containing available target types in the TOM
+
+                  `extra_form`: ``FormSet``: Django formset with fields for arbitrary key/value pairs
+        :rtype: dict
+        """
+        context = super(TargetCreateView, self).get_context_data(**kwargs)
+        context['type_choices'] = Target.TARGET_TYPES
+        #context['names_form'] = TargetNamesFormset(initial=[{'name': new_name}
+        #                                                    for new_name
+        #                                                    in self.request.GET.get('names', '').split(',')])
+        #context['extra_form'] = TargetExtraFormset()
+
+        context['target_nle_form'] = TargetNLEForm()
+        
+        return context
+
+    def form_valid(self, form):
+
+        # do the normal form_valid from the TOMToolkit TargetCreateView 
+        super(CreateView, self).form_valid(form)
+
+        # then also associate this target with the chosen NLE
+
+        # Get the newly created target
+        target = self.object
+        
+        # Get the selected NLE from the POST data
+        nle_id = self.request.POST.get('nle_select')
+
+        if nle_id:
+            try:
+                logger.info("Creating an EventCandidate from the user specific target and NLE")
+                ec, created = EventCandidate.objects.get_or_create(
+                    target=target,
+                    nonlocalizedevent=NonLocalizedEvent.objects.get(event_id=nle_id),
+                )
+            except NonLocalizedEvent.DoesNotExist:
+                logger.info(f"User passed an invalid NLE id {nle_id}, skipping!")
+                form.add_error(None, "Invalid NLE Event ID!")
+                return super().form_invalid(form)
+
+            logger.info("EventCandidate successfully created!")
+
+        # Give the user access to the target they created
+        self.object.give_user_access(self.request.user)
+
+        # Run the target post save hook
+        logger.info('Target post save hook: %s created: %s', target, True)
+        run_hook('target_post_save', target=target, created=True)
+        
+        return redirect(self.get_success_url())
+
+            
+        

--- a/trove_targets/views.py
+++ b/trove_targets/views.py
@@ -1,11 +1,20 @@
+import logging
+
 from django.shortcuts import render, redirect
 from django.views.generic.edit import CreateView
+from dal import autocomplete
+
+from tom_common.hooks import run_hook
+
 from tom_targets.views import TargetCreateView
 from tom_targets.models import Target
-from .forms import TargetNLEForm
+from tom_targets.forms import TargetForm, SiderealTargetCreateForm
 
-from dal import autocomplete
-from tom_nonlocalizedevents.models import NonLocalizedEvent
+from tom_nonlocalizedevents.models import NonLocalizedEvent, EventCandidate
+
+from .forms import TargetNLEForm, CustomSiderealTargetCreateForm
+
+logger = logging.getLogger(__name__)
 
 class NLEAutocompleteView(autocomplete.Select2QuerySetView):
 
@@ -34,8 +43,8 @@ class CustomTargetCreateView(TargetCreateView):
                   `extra_form`: ``FormSet``: Django formset with fields for arbitrary key/value pairs
         :rtype: dict
         """
-        context = super(TargetCreateView, self).get_context_data(**kwargs)
-        context['type_choices'] = Target.TARGET_TYPES
+        context = super(CustomTargetCreateView, self).get_context_data(**kwargs)
+        context['type_choices'] = [("SIDEREAL", "Sidereal")] #Target.TARGET_TYPES
         #context['names_form'] = TargetNamesFormset(initial=[{'name': new_name}
         #                                                    for new_name
         #                                                    in self.request.GET.get('names', '').split(',')])
@@ -48,13 +57,13 @@ class CustomTargetCreateView(TargetCreateView):
     def form_valid(self, form):
 
         # do the normal form_valid from the TOMToolkit TargetCreateView 
-        super(CreateView, self).form_valid(form)
+        super(TargetCreateView, self).form_valid(form)
 
         # then also associate this target with the chosen NLE
 
         # Get the newly created target
         target = self.object
-        
+
         # Get the selected NLE from the POST data
         nle_id = self.request.POST.get('nle_select')
 
@@ -63,7 +72,7 @@ class CustomTargetCreateView(TargetCreateView):
                 logger.info("Creating an EventCandidate from the user specific target and NLE")
                 ec, created = EventCandidate.objects.get_or_create(
                     target=target,
-                    nonlocalizedevent=NonLocalizedEvent.objects.get(event_id=nle_id),
+                    nonlocalizedevent=NonLocalizedEvent.objects.get(id=nle_id),
                 )
             except NonLocalizedEvent.DoesNotExist:
                 logger.info(f"User passed an invalid NLE id {nle_id}, skipping!")
@@ -81,5 +90,11 @@ class CustomTargetCreateView(TargetCreateView):
         
         return redirect(self.get_success_url())
 
+    def get_form_class(self):
+        form_class = super(CustomTargetCreateView, self).get_form_class()
+        print("ORIGINAL FORM CLASS:", form_class)
+        if issubclass(form_class, SiderealTargetCreateForm):
+            form_class = CustomSiderealTargetCreateForm
             
-        
+        print("Returning", form_class, form_class._meta.fields)
+        return form_class


### PR DESCRIPTION
This PR updates the target creation form to 
1. Allow the user to provide an NLE association
2. Make the upload form more user friendly (no typing in various "target extras", instead if just allows for the direct addition of e.g., a redshift and classification)

To test this you should just try to create a target from the Target page > Create a Target dropdown.

I also removed some of the unnecessary buttons from the target pages like the "Share" and "Report" buttons. I left the Delete button but I have some code commented out that should only display this button for TROVE admins. However, something is up with how the TOMToolkit is sending the request context. I've sent a slack message and we can implement this when they get back to me! 