### PR TITLE
Make an empty dataframe with appropriate columns if no host matches

### DIFF
--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -504,6 +504,12 @@ def host_association(
             ]
         )
 
+    if not res: # if no host matches
+        cols = list(HOST_DF_COLMAP.keys()) + ["z_neg_err", "z_pos_err", "lumdist_neg_err", "lumdist_pos_err"]
+        rows = []*len(cols)
+        res.append(pd.DataFrame(rows, columns=cols)) # append empty df with appropriate columns
+
+    # concact results of individual catalogs into one dataframe
     df = pd.concat(res).reset_index(drop=True)
 
     # TODO: We will need to put some deduplication code for the galaxy dataframe

--- a/candidate_vetting/vet.py
+++ b/candidate_vetting/vet.py
@@ -506,7 +506,7 @@ def host_association(
 
     if not res: # if no host matches
         cols = list(HOST_DF_COLMAP.keys()) + ["z_neg_err", "z_pos_err", "lumdist_neg_err", "lumdist_pos_err"]
-        rows = []*len(cols)
+        rows = []
         res.append(pd.DataFrame(rows, columns=cols)) # append empty df with appropriate columns
 
     # concact results of individual catalogs into one dataframe


### PR DESCRIPTION
When no catalogs yield a match and `res` is an empty list, the pandas `concat` function throws an exception. This resolves this by making an empty dataframe and appending it to `res` when `res` is empty.