### PR TITLE
Sort GWs by -event_id rather than -created

### DIFF
--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -250,7 +250,7 @@ class GWListView(NonLocalizedEventListView):
     formhelper_class = GWFormHelper
 
     def get_queryset(self):
-        qs = NonLocalizedEvent.objects.filter(event_type='GW').order_by('-created')
+        qs = NonLocalizedEvent.objects.filter(event_type='GW').order_by('-event_id')
         return qs
 
 


### PR DESCRIPTION
Teeny tiny change but wanted to open as a PR in case any objections. 

Without this change, something like the S190814bv we ingested earlier is higher up on the list than S251112cm. 

This change makes sense for GWs, which are all of the form SYYMMDDabcd or GWYYMMDD. Not necessarily the case for GRBs, X-ray transients, or neutrinos, at least based on looking at the lists currently on SAGUARO, so didn't touch those views.