### PR TITLE
Fix broken NED cone-search links in Host Galaxies table

### DIFF
--- a/templates/tom_targets/partials/galaxy_table.html
+++ b/templates/tom_targets/partials/galaxy_table.html
@@ -16,7 +16,7 @@
   {% for galaxy in galaxies %}
     <tr>
       <td>{{ forloop.counter }}</td>
-      <td><a href="https://ned.ipac.caltech.edu/conesearch?search_type=Near%20Position%20Search&coordinates={{galaxy.RA}}d,{{galaxy.Dec}}d&radius=0.02" target="_blank">{{ galaxy.ID }}</a></td>
+      <td><a href="https://ned.ipac.caltech.edu/conesearch?search_type=Near%20Position%20Search&in_csys=Equatorial&in_equinox=J2000&ra={{galaxy.RA}}d&dec={{galaxy.Dec}}d&radius=0.02" target="_blank">{{ galaxy.ID }}</a></td>
       <td>{{ galaxy.PCC|floatformat:3 }}</td>
       <td>{{ galaxy.Offset|floatformat:2 }}</td>
       {% if galaxy.Dist and galaxy.Dist|floatformat != 'nan' %}


### PR DESCRIPTION
## Summary

Fixes Host Galaxies name links on target pages so they open a working NED cone search instead of a broken URL.

Replaces the deprecated `coordinates=ra,dec` query format with explicit equatorial J2000 parameters: `in_csys=Equatorial`, `in_equinox=J2000`, `ra=...`, and `dec=...`.

Closes: https://github.com/astro-trove/trove/issues/141