### PR TITLE
add VLASS QL stacks to ALADIN viewer

### DIFF
--- a/templates/tom_targets/partials/aladin_custom.html
+++ b/templates/tom_targets/partials/aladin_custom.html
@@ -61,6 +61,15 @@
       annotateChart({{ target.ra }}, {{ target.dec }}, {{ galaxy_ras }}, {{galaxy_decs}});
     });
 
+    aladin.createImageSurvey(
+	'VLASS-QL-MedianStack-20250131',
+	'VLASS',
+	'https://vlass-dl.nrao.edu/vlass/HiPS/MedianStack/Quicklook',
+	'equatorial',
+	9,
+	{imgFormat: 'png'}
+    );
+
     function getScaleBarFromForm() {
       let size = Number($('#scale-bar-size').val());
       if (size < 0) {


### PR DESCRIPTION
Small PR, does as the title says and just adds VLASS QL stacks to the ALADIN viewer on the target pages. To test you can go to any target page and use the dropdown to change the layer. A fun one to look at is the AGN S251112cm_X3 which has a nice radio source underneath the target position :)

closes #186 