### PR TITLE
Fix and improve the GW ingestion code

### DIFF
--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -331,7 +331,7 @@ def handle_message_and_send_alerts(message, metadata):
     
     # check for targets over appropriate time horizon
     nle_eventseq = localization_sequence_from_name(nle.event_id)
-    nle_most_likely_class = get_most_likely_class(nle_eventseq)  # most likely class for the NLE
+    nle_most_likely_class = get_most_likely_class(nle_eventseq.details)  # most likely class for the NLE
     associate_targets_with_nle(
         nle,
         DETECTION_HORIZON_DEFAULTS[nle_most_likely_class][0],

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -1,15 +1,31 @@
-from tom_nonlocalizedevents.models import NonLocalizedEvent, EventSequence, EventCandidate
-from tom_nonlocalizedevents.alertstream_handlers.igwn_event_handler import handle_igwn_message
+import time
+import json
+from datetime import datetime
+import traceback
+from io import BytesIO
+
+import numpy as np
+
+from email.mime.text import MIMEText
+# from slack_sdk import WebClient
+import smtplib
+
 from django.contrib.auth.models import Group
 from django.contrib.sites.models import Site
 from django.conf import settings
-from email.mime.text import MIMEText
 
-# from slack_sdk import WebClient
-import smtplib
-import logging
+from tom_nonlocalizedevents.models import NonLocalizedEvent, EventSequence, EventCandidate
+from tom_nonlocalizedevents.alertstream_handlers.igwn_event_handler import handle_igwn_message
 from tom_dataproducts.tasks import atlas_query
-from .hooks import target_post_save
+
+from astropy.table import Table
+from astropy.time import Time
+import astropy_healpix as ah
+
+from .hooks import (
+    target_post_save,
+    associate_targets_with_nle,
+)
 from .templatetags.nonlocalizedevent_extras import (
     format_inverse_far,
     format_distance,
@@ -18,19 +34,14 @@ from .templatetags.nonlocalizedevent_extras import (
 )
 from .healpix_utils import create_elliptical_localization
 from .models import CredibleRegionContour
-from .hooks import associate_targets_with_nle
-from astropy.table import Table
-from astropy.time import Time
-from datetime import datetime
-from io import BytesIO
-import astropy_healpix as ah
-import numpy as np
-import traceback
-from trove_targets.models import Target
-import time
-import json
 
+from candidate_vetting.vet import localization_sequence_from_name
+from scoring.config import DETECTION_HORIZON_DEFAULTS
+from trove_targets.models import Target
+
+import logging
 logger = logging.getLogger(__name__)
+
 
 # for einstein probe
 ALERT_TEXT_EP = """Einstein Probe trigger <{target_link}|{{target.name}}>
@@ -318,8 +329,14 @@ def handle_message_and_send_alerts(message, metadata):
                 skymap = Table.read(BytesIO(skymap_bytes))
                 calculate_credible_region(skymap, localization)
     
-    # check for candidates since the trigger time
-    associate_targets_with_nle(nle, -1, 10)
+    # check for targets over appropriate time horizon
+    nle_eventseq = localization_sequence_from_name(nle.event_id)
+    nle_most_likely_class = get_most_likely_class(nle_eventseq)  # most likely class for the NLE
+    associate_targets_with_nle(
+        nle,
+        DETECTION_HORIZON_DEFAULTS[nle_most_likely_class][0],
+        DETECTION_HORIZON_DEFAULTS[nle_most_likely_class][-1]
+    )
 
     logger.info(f"Finished processing alert for {nle.event_id}")
     return nle, seq

--- a/custom_code/alertstream_handlers.py
+++ b/custom_code/alertstream_handlers.py
@@ -18,6 +18,7 @@ from .templatetags.nonlocalizedevent_extras import (
 )
 from .healpix_utils import create_elliptical_localization
 from .models import CredibleRegionContour
+from .hooks import associate_targets_with_nle
 from astropy.table import Table
 from astropy.time import Time
 from datetime import datetime
@@ -284,6 +285,9 @@ def prepare_and_send_alerts(nle, seq):
 
 def handle_message_and_send_alerts(message, metadata):
 
+    # because they change the alert format but tom_nonlocalizedevents doesn't expect it
+    message.content = [message.content]
+    
     # get skymap bytes out for later
     skymaps = []
     try:
@@ -313,6 +317,9 @@ def handle_message_and_send_alerts(message, metadata):
             if skymap_bytes is not None:
                 skymap = Table.read(BytesIO(skymap_bytes))
                 calculate_credible_region(skymap, localization)
+    
+    # check for candidates since the trigger time
+    associate_targets_with_nle(nle, -1, 10)
 
     logger.info(f"Finished processing alert for {nle.event_id}")
     return nle, seq

--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime, timedelta, timezone
 import numpy as np
+from django.db.models import Min
 from tom_targets.models import TargetExtra
 from tom_nonlocalizedevents.models import NonLocalizedEvent
 from tom_dataproducts.models import ReducedDatum
@@ -121,7 +122,36 @@ def associate_nle_with_target(
 
     return new_candidates
 
+def associate_targets_with_nle(
+    nle:NonLocalizedEvent, first_det_min, first_det_max   
+):
+    # get info on the NLE
+    seq = nle.sequences.last()
+    localization = get_preferred_localization(nle)
+    try:
+        nle_time = datetime.strptime(seq.details["time"], "%Y-%m-%dT%H:%M:%S.%f%z")
+    except ValueError:
+        nle_time = datetime.strptime(seq.details["time"], "%Y-%m-%dT%H:%M:%S.%f")
 
+    # query for relevant targets
+    targets = ReducedDatum.objects.filter(
+        data_type="photometry",
+        value__magnitude__isnull=False
+    ).values(
+        "target_id"
+    ).annotate(
+        min_timestamp=Min("timestamp")
+    ).filter(
+        min_timestamp__gt = nle_time + timedelta(days=first_det_min),
+        min_timestamp__lt = nle_time + timedelta(days=first_det_max)
+    ).values_list(
+        "target_id",
+        flat=True
+    )
+
+    # then create candidates from these targets and return them
+    return create_candidates_from_targets(seq, target_ids=list(targets)) 
+    
 def target_post_save(
     target,
     created=True,

--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -1,20 +1,16 @@
 import logging
 from datetime import datetime, timedelta, timezone
-import numpy as np
 from django.db.models import Min
 from tom_targets.models import TargetExtra
 from tom_nonlocalizedevents.models import NonLocalizedEvent
 from tom_dataproducts.models import ReducedDatum
 
-from scoring.vet_phot import find_public_phot
 from scoring.vet_bns import vet_bns
 from scoring.vet_kn_in_sn import vet_kn_in_sn
 from scoring.vet_super_kn import vet_super_kn
 from scoring.vet_basic import vet_basic
 
-from candidate_vetting.public_catalogs.phot_catalogs import TNS_Phot
 from custom_code.healpix_utils import create_candidates_from_targets
-from custom_code.templatetags.skymap_extras import get_preferred_localization
 from trove_targets.models import Target
 from astropy.time import Time, TimezoneInfo
 from astropy.coordinates import SkyCoord
@@ -97,7 +93,6 @@ def associate_nle_with_target(
     new_candidates = []
     for nle in get_active_nonlocalizedevents(lookback_days=lookback_days_nle):
         seq = nle.sequences.last()
-        localization = get_preferred_localization(nle)
         try:
             nle_time = datetime.strptime(seq.details["time"], "%Y-%m-%dT%H:%M:%S.%f%z")
         except ValueError:
@@ -127,7 +122,6 @@ def associate_targets_with_nle(
 ):
     # get info on the NLE
     seq = nle.sequences.last()
-    localization = get_preferred_localization(nle)
     try:
         nle_time = datetime.strptime(seq.details["time"], "%Y-%m-%dT%H:%M:%S.%f%z")
     except ValueError:


### PR DESCRIPTION
This does two things:
1. It fixes the GW ingestion code for the new alert format
2. Adds automatic candidate association for new NLEs that we ingest

@nvieira-astro To test you can just run `./manage.py readstreams`.

@PhillNo once we merge this we can turn back on the alert stream listener in the integration deployment!